### PR TITLE
Debug/variable value

### DIFF
--- a/org.emoflon.gips.build/src/org/emoflon/gips/build/transformation/transformer/AttributeExpressionTransformer.java
+++ b/org.emoflon.gips.build/src/org/emoflon/gips/build/transformation/transformer/AttributeExpressionTransformer.java
@@ -9,7 +9,6 @@ import org.emoflon.gips.build.transformation.helper.TransformationContext;
 import org.emoflon.gips.gipsl.gipsl.GipsAttributeExpr;
 import org.emoflon.gips.gipsl.gipsl.GipsContains;
 import org.emoflon.gips.gipsl.gipsl.GipsContextExpr;
-import org.emoflon.gips.gipsl.gipsl.GipsContextOperationExpression;
 import org.emoflon.gips.gipsl.gipsl.GipsFeatureExpr;
 import org.emoflon.gips.gipsl.gipsl.GipsFeatureLit;
 import org.emoflon.gips.gipsl.gipsl.GipsLambdaAttributeExpression;
@@ -27,6 +26,7 @@ import org.emoflon.gips.gipsl.gipsl.GipsStreamBoolExpr;
 import org.emoflon.gips.gipsl.gipsl.GipsStreamExpr;
 import org.emoflon.gips.gipsl.gipsl.GipsTypeAttributeExpr;
 import org.emoflon.gips.gipsl.gipsl.GipsTypeContext;
+import org.emoflon.gips.gipsl.gipsl.GipsVariableOperationExpression;
 import org.emoflon.gips.gipsl.scoping.GipslScopeContextUtil;
 import org.emoflon.gips.intermediate.GipsIntermediate.ContextMappingNode;
 import org.emoflon.gips.intermediate.GipsIntermediate.ContextMappingNodeFeatureValue;
@@ -199,7 +199,7 @@ public abstract class AttributeExpressionTransformer<T extends EObject> extends 
 			} else {
 				throw new UnsupportedOperationException("Nested stream expressions are not yet allowed!");
 			}
-		} else if (eLambda.getExpr() instanceof GipsContextOperationExpression eContextOp) {
+		} else if (eLambda.getExpr() instanceof GipsVariableOperationExpression eContextOp) {
 			if (streamRoot instanceof GipsMappingAttributeExpr eMappingAttribute) {
 				return transformVariableStreamOperation(eContextOp, eMappingAttribute, streamIteratorContainer);
 			} else {
@@ -473,7 +473,7 @@ public abstract class AttributeExpressionTransformer<T extends EObject> extends 
 								"Some constrains contain invalid values within arithmetic expressions, e.g., objects or streams of objects instead of arithmetic values.");
 					}
 				}
-			} else if (eContext.getExpr() instanceof GipsContextOperationExpression eContextOp) {
+			} else if (eContext.getExpr() instanceof GipsVariableOperationExpression eContextOp) {
 				throw new UnsupportedOperationException(
 						"Node and ILP variable (e.g., .value(), .isMapped()) expressions may not followed by stream expressions.");
 			} else {
@@ -566,7 +566,7 @@ public abstract class AttributeExpressionTransformer<T extends EObject> extends 
 		return patternFeature;
 	}
 
-	protected ValueExpression transformVariableStreamOperation(final GipsContextOperationExpression eContextOp,
+	protected ValueExpression transformVariableStreamOperation(final GipsVariableOperationExpression eContextOp,
 			final GipsMappingAttributeExpr eMappingAttribute, final GipsStreamExpr streamIteratorContainer)
 			throws Exception {
 		if (eContextOp instanceof GipsMappingValue mappingValueOp) {

--- a/org.emoflon.gips.build/src/org/emoflon/gips/build/transformation/transformer/AttributeInStreamTransformer.java
+++ b/org.emoflon.gips.build/src/org/emoflon/gips/build/transformation/transformer/AttributeInStreamTransformer.java
@@ -4,11 +4,11 @@ import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EObject;
 import org.emoflon.gips.build.transformation.helper.GipsTransformationData;
 import org.emoflon.gips.gipsl.gipsl.GipsContextExpr;
-import org.emoflon.gips.gipsl.gipsl.GipsContextOperationExpression;
 import org.emoflon.gips.gipsl.gipsl.GipsMappingAttributeExpr;
 import org.emoflon.gips.gipsl.gipsl.GipsPatternContext;
 import org.emoflon.gips.gipsl.gipsl.GipsStreamExpr;
 import org.emoflon.gips.gipsl.gipsl.GipsTypeContext;
+import org.emoflon.gips.gipsl.gipsl.GipsVariableOperationExpression;
 import org.emoflon.gips.intermediate.GipsIntermediate.ContextPatternValue;
 import org.emoflon.gips.intermediate.GipsIntermediate.ContextTypeValue;
 import org.emoflon.gips.intermediate.GipsIntermediate.Pattern;
@@ -50,7 +50,7 @@ public class AttributeInStreamTransformer extends AttributeExpressionTransformer
 	}
 
 	@Override
-	protected ValueExpression transformVariableStreamOperation(GipsContextOperationExpression eContextOp,
+	protected ValueExpression transformVariableStreamOperation(GipsVariableOperationExpression eContextOp,
 			GipsMappingAttributeExpr eMappingAttribute, GipsStreamExpr streamIteratorContainer) throws Exception {
 		throw new UnsupportedOperationException("ILP variable access ist not allowed in stream expressions.");
 	}

--- a/org.emoflon.gips.build/src/org/emoflon/gips/build/transformation/transformer/AttributeInSumTransformer.java
+++ b/org.emoflon.gips.build/src/org/emoflon/gips/build/transformation/transformer/AttributeInSumTransformer.java
@@ -2,15 +2,18 @@ package org.emoflon.gips.build.transformation.transformer;
 
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EcorePackage;
 import org.emoflon.gips.build.transformation.helper.GipsTransformationData;
 import org.emoflon.gips.gipsl.gipsl.GipsContextExpr;
 import org.emoflon.gips.gipsl.gipsl.GipsMappingAttributeExpr;
+import org.emoflon.gips.gipsl.gipsl.GipsMappingValue;
 import org.emoflon.gips.gipsl.gipsl.GipsPatternContext;
 import org.emoflon.gips.gipsl.gipsl.GipsStreamExpr;
 import org.emoflon.gips.gipsl.gipsl.GipsTypeContext;
 import org.emoflon.gips.gipsl.gipsl.GipsVariableOperationExpression;
 import org.emoflon.gips.intermediate.GipsIntermediate.ContextPatternValue;
 import org.emoflon.gips.intermediate.GipsIntermediate.ContextTypeValue;
+import org.emoflon.gips.intermediate.GipsIntermediate.IteratorMappingVariableValue;
 import org.emoflon.gips.intermediate.GipsIntermediate.Pattern;
 import org.emoflon.gips.intermediate.GipsIntermediate.SumExpression;
 import org.emoflon.gips.intermediate.GipsIntermediate.Type;
@@ -52,7 +55,16 @@ public class AttributeInSumTransformer extends AttributeExpressionTransformer<Su
 	@Override
 	protected ValueExpression transformVariableStreamOperation(GipsVariableOperationExpression eContextOp,
 			GipsMappingAttributeExpr eMappingAttribute, GipsStreamExpr streamIteratorContainer) throws Exception {
-		throw new UnsupportedOperationException("ILP variable access ist not allowed in stream expressions.");
+		if (eContextOp instanceof GipsMappingValue mpValue) {
+			IteratorMappingVariableValue mappingValue = factory.createIteratorMappingVariableValue();
+			mappingValue.setMappingContext(data.eMapping2Mapping().get(eMappingAttribute.getMapping()));
+			mappingValue.setStream(data.eStream2SetOp().get(streamIteratorContainer));
+			mappingValue.setReturnType(EcorePackage.Literals.EINT);
+			return mappingValue;
+		} else {
+			throw new UnsupportedOperationException(
+					"Nested ILP variable constraint expressions are not allowed in stream expressions.");
+		}
 	}
 
 }

--- a/org.emoflon.gips.build/src/org/emoflon/gips/build/transformation/transformer/AttributeInSumTransformer.java
+++ b/org.emoflon.gips.build/src/org/emoflon/gips/build/transformation/transformer/AttributeInSumTransformer.java
@@ -4,11 +4,11 @@ import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EObject;
 import org.emoflon.gips.build.transformation.helper.GipsTransformationData;
 import org.emoflon.gips.gipsl.gipsl.GipsContextExpr;
-import org.emoflon.gips.gipsl.gipsl.GipsContextOperationExpression;
 import org.emoflon.gips.gipsl.gipsl.GipsMappingAttributeExpr;
 import org.emoflon.gips.gipsl.gipsl.GipsPatternContext;
 import org.emoflon.gips.gipsl.gipsl.GipsStreamExpr;
 import org.emoflon.gips.gipsl.gipsl.GipsTypeContext;
+import org.emoflon.gips.gipsl.gipsl.GipsVariableOperationExpression;
 import org.emoflon.gips.intermediate.GipsIntermediate.ContextPatternValue;
 import org.emoflon.gips.intermediate.GipsIntermediate.ContextTypeValue;
 import org.emoflon.gips.intermediate.GipsIntermediate.Pattern;
@@ -50,7 +50,7 @@ public class AttributeInSumTransformer extends AttributeExpressionTransformer<Su
 	}
 
 	@Override
-	protected ValueExpression transformVariableStreamOperation(GipsContextOperationExpression eContextOp,
+	protected ValueExpression transformVariableStreamOperation(GipsVariableOperationExpression eContextOp,
 			GipsMappingAttributeExpr eMappingAttribute, GipsStreamExpr streamIteratorContainer) throws Exception {
 		throw new UnsupportedOperationException("ILP variable access ist not allowed in stream expressions.");
 	}

--- a/org.emoflon.gips.build/src/org/emoflon/gips/build/transformation/transformer/RelationalInConstraintTransformer.java
+++ b/org.emoflon.gips.build/src/org/emoflon/gips/build/transformation/transformer/RelationalInConstraintTransformer.java
@@ -9,7 +9,6 @@ import org.emoflon.gips.build.transformation.helper.TransformationContext;
 import org.emoflon.gips.gipsl.gipsl.GipsAttributeExpr;
 import org.emoflon.gips.gipsl.gipsl.GipsContains;
 import org.emoflon.gips.gipsl.gipsl.GipsContextExpr;
-import org.emoflon.gips.gipsl.gipsl.GipsContextOperationExpression;
 import org.emoflon.gips.gipsl.gipsl.GipsMappingAttributeExpr;
 import org.emoflon.gips.gipsl.gipsl.GipsMappingCheckValue;
 import org.emoflon.gips.gipsl.gipsl.GipsMappingContext;
@@ -22,6 +21,7 @@ import org.emoflon.gips.gipsl.gipsl.GipsStreamBoolExpr;
 import org.emoflon.gips.gipsl.gipsl.GipsStreamExpr;
 import org.emoflon.gips.gipsl.gipsl.GipsTypeAttributeExpr;
 import org.emoflon.gips.gipsl.gipsl.GipsTypeContext;
+import org.emoflon.gips.gipsl.gipsl.GipsVariableOperationExpression;
 import org.emoflon.gips.gipsl.scoping.GipslScopeContextUtil;
 import org.emoflon.gips.intermediate.GipsIntermediate.ArithmeticValue;
 import org.emoflon.gips.intermediate.GipsIntermediate.Constraint;
@@ -63,7 +63,7 @@ public class RelationalInConstraintTransformer extends TransformationContext<Con
 						EObject contextType = GipslScopeContextUtil.getContextType(eContextAttribute);
 						if (contextType instanceof GipsMappingContext mappingContext) {
 							if (eContextAttribute
-									.getExpr() instanceof GipsContextOperationExpression contextOperation) {
+									.getExpr() instanceof GipsVariableOperationExpression contextOperation) {
 								return createUnaryConstraintCondition(contextOperation);
 							} else if (eContextAttribute
 									.getExpr() instanceof GipsNodeAttributeExpr nodeAttributeExpression
@@ -158,8 +158,8 @@ public class RelationalInConstraintTransformer extends TransformationContext<Con
 		}
 	}
 
-	protected RelationalExpression createUnaryConstraintCondition(final GipsContextOperationExpression contextOperation)
-			throws Exception {
+	protected RelationalExpression createUnaryConstraintCondition(
+			final GipsVariableOperationExpression contextOperation) throws Exception {
 		if (contextOperation instanceof GipsMappingValue mappingValueOp) {
 			throw new UnsupportedOperationException(
 					"Some constrains contain invalid values within boolean expressions, e.g., arithmetic values instead of boolean values.");

--- a/org.emoflon.gips.gipsl/model/generated/Gipsl.ecore
+++ b/org.emoflon.gips.gipsl/model/generated/Gipsl.ecore
@@ -103,7 +103,7 @@
     <eLiterals name="SMALLER" value="5" literal="&lt;"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="GipsAttributeExpr" eSuperTypes="#//GipsExpressionOperand"/>
-  <eClassifiers xsi:type="ecore:EClass" name="GipsContextOperationExpression"/>
+  <eClassifiers xsi:type="ecore:EClass" name="GipsVariableOperationExpression"/>
   <eClassifiers xsi:type="ecore:EClass" name="GipsTypeCast">
     <eStructuralFeatures xsi:type="ecore:EReference" name="type" eType="ecore:EClass http://www.eclipse.org/emf/2002/Ecore#//EClass"/>
   </eClassifiers>
@@ -223,8 +223,8 @@
     <eStructuralFeatures xsi:type="ecore:EReference" name="stream" eType="#//GipsStreamExpr"
         containment="true"/>
   </eClassifiers>
-  <eClassifiers xsi:type="ecore:EClass" name="GipsMappingValue" eSuperTypes="#//GipsContextOperationExpression"/>
-  <eClassifiers xsi:type="ecore:EClass" name="GipsMappingCheckValue" eSuperTypes="#//GipsContextOperationExpression">
+  <eClassifiers xsi:type="ecore:EClass" name="GipsMappingValue" eSuperTypes="#//GipsVariableOperationExpression"/>
+  <eClassifiers xsi:type="ecore:EClass" name="GipsMappingCheckValue" eSuperTypes="#//GipsVariableOperationExpression">
     <eStructuralFeatures xsi:type="ecore:EReference" name="count" eType="#//GipsAttributeExpr"
         containment="true"/>
   </eClassifiers>

--- a/org.emoflon.gips.gipsl/model/generated/Gipsl.genmodel
+++ b/org.emoflon.gips.gipsl/model/generated/Gipsl.genmodel
@@ -129,7 +129,7 @@
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Gipsl.ecore#//GipsRelExpr/right"/>
     </genClasses>
     <genClasses ecoreClass="Gipsl.ecore#//GipsAttributeExpr"/>
-    <genClasses ecoreClass="Gipsl.ecore#//GipsContextOperationExpression"/>
+    <genClasses ecoreClass="Gipsl.ecore#//GipsVariableOperationExpression"/>
     <genClasses ecoreClass="Gipsl.ecore#//GipsTypeCast">
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference Gipsl.ecore#//GipsTypeCast/type"/>
     </genClasses>

--- a/org.emoflon.gips.gipsl/src/org/emoflon/gips/gipsl/Gipsl.xtext
+++ b/org.emoflon.gips.gipsl/src/org/emoflon/gips/gipsl/Gipsl.xtext
@@ -151,7 +151,7 @@ GipsPatternAttributeExpr returns GipsAttributeExpr: {GipsPatternAttributeExpr}
 
 //TODO: Allow optional nested lambda expressions
 GipsLambdaAttributeExpression returns GipsAttributeExpr: {GipsLambdaAttributeExpression}
-	var=[GipsLambdaExpression|ID] '.' (expr = GipsNodeAttributeExpr | expr = GipsContextOperationExpression | expr = GipsFeatureExpr) // ('->' stream = GipsStreamExpr)?
+	var=[GipsLambdaExpression|ID] '.' (expr = GipsNodeAttributeExpr | expr = GipsVariableOperationExpression | expr = GipsFeatureExpr) // ('->' stream = GipsStreamExpr)?
 ;
 
 GipsLambdaSelfExpression returns GipsAttributeExpr: {GipsLambdaSelfExpression}
@@ -159,10 +159,10 @@ GipsLambdaSelfExpression returns GipsAttributeExpr: {GipsLambdaSelfExpression}
 ;
 
 GipsContextExpr returns GipsAttributeExpr: {GipsContextExpr}
-	'self' ('.' typeCast=GipsTypeCast)? ('.' (expr = GipsNodeAttributeExpr | expr = GipsContextOperationExpression | expr = GipsFeatureExpr) ('->' stream = GipsStreamExpr)?)?
+	'self' ('.' typeCast=GipsTypeCast)? ('.' (expr = GipsNodeAttributeExpr | expr = GipsVariableOperationExpression | expr = GipsFeatureExpr) ('->' stream = GipsStreamExpr)?)?
 ;
 
-GipsContextOperationExpression returns GipsContextOperationExpression: 
+GipsVariableOperationExpression returns GipsVariableOperationExpression: 
 	{GipsMappingValue} 'value()' |
 	{GipsMappingCheckValue} 'isMapped' '(' (count=GipsContextExpr)? ')'
 ;

--- a/org.emoflon.gips.gipsl/src/org/emoflon/gips/gipsl/validation/GipslValidator.java
+++ b/org.emoflon.gips.gipsl/src/org/emoflon/gips/gipsl/validation/GipslValidator.java
@@ -30,7 +30,6 @@ import org.emoflon.gips.gipsl.gipsl.GipsConstant;
 import org.emoflon.gips.gipsl.gipsl.GipsConstraint;
 import org.emoflon.gips.gipsl.gipsl.GipsContains;
 import org.emoflon.gips.gipsl.gipsl.GipsContextExpr;
-import org.emoflon.gips.gipsl.gipsl.GipsContextOperationExpression;
 import org.emoflon.gips.gipsl.gipsl.GipsExpArithmeticExpr;
 import org.emoflon.gips.gipsl.gipsl.GipsExpOperator;
 import org.emoflon.gips.gipsl.gipsl.GipsExpressionOperand;
@@ -73,9 +72,10 @@ import org.emoflon.gips.gipsl.gipsl.GipsTypeAttributeExpr;
 import org.emoflon.gips.gipsl.gipsl.GipsTypeCast;
 import org.emoflon.gips.gipsl.gipsl.GipsTypeContext;
 import org.emoflon.gips.gipsl.gipsl.GipsUnaryArithmeticExpr;
+import org.emoflon.gips.gipsl.gipsl.GipsVariableOperationExpression;
 import org.emoflon.gips.gipsl.gipsl.GipslPackage;
-import org.emoflon.gips.gipsl.scoping.GipslScopeContextUtil;
 import org.emoflon.gips.gipsl.gipsl.GlobalContext;
+import org.emoflon.gips.gipsl.scoping.GipslScopeContextUtil;
 import org.emoflon.ibex.gt.editor.gT.EditorNode;
 
 /**
@@ -520,7 +520,7 @@ public class GipslValidator extends AbstractGipslValidator {
 				if (exprOp instanceof GipsContextExpr) {
 					final GipsContextExpr conExpr = (GipsContextExpr) exprOp;
 					// Streams can be ignored
-					return conExpr.getExpr() instanceof GipsContextOperationExpression;
+					return conExpr.getExpr() instanceof GipsVariableOperationExpression;
 				} else if (exprOp instanceof GipsLambdaAttributeExpression) {
 					// A GipsLambdaAttributeExpression can not contain an isMapped call
 					return false;
@@ -699,7 +699,7 @@ public class GipslValidator extends AbstractGipslValidator {
 					if (streamContainsMappingsCall(conExpr.getStream())) {
 						return true;
 					}
-					return (conExpr.getExpr() instanceof GipsContextOperationExpression
+					return (conExpr.getExpr() instanceof GipsVariableOperationExpression
 							&& !(conExpr.getExpr() instanceof GipsMappingCheckValue));
 				} else if (exprOp instanceof GipsLambdaAttributeExpression) {
 					// A GipsLambdaAttributeExpression can not contain a mappings call
@@ -1163,7 +1163,7 @@ public class GipslValidator extends AbstractGipslValidator {
 				if (exprOp instanceof GipsContextExpr) {
 					final GipsContextExpr conExpr = (GipsContextExpr) exprOp;
 					// Currently only MAPPED and VALUE are supported -> Both are dynamic
-					return conExpr.getExpr() instanceof GipsContextOperationExpression;
+					return conExpr.getExpr() instanceof GipsVariableOperationExpression;
 					// TODO: Use the solution below. But, in order for this to work, we need to
 					// implement a multivariate return value (Enum type), which conveys more
 					// information that just "there is a mapping access of some kind".
@@ -1708,8 +1708,8 @@ public class GipslValidator extends AbstractGipslValidator {
 		final EObject innerExpr = expr.getExpr();
 		if (innerExpr instanceof GipsNodeAttributeExpr) {
 			return getEvalTypeFromNodeAttrExpr((GipsNodeAttributeExpr) innerExpr);
-		} else if (innerExpr instanceof GipsContextOperationExpression) {
-			return getEvalTypeFromContextOpExpr((GipsContextOperationExpression) innerExpr);
+		} else if (innerExpr instanceof GipsVariableOperationExpression) {
+			return getEvalTypeFromContextOpExpr((GipsVariableOperationExpression) innerExpr);
 		} else if (innerExpr instanceof GipsFeatureExpr) {
 			return getEvalTypeFromFeatureExpr((GipsFeatureExpr) innerExpr);
 		}
@@ -1727,8 +1727,8 @@ public class GipslValidator extends AbstractGipslValidator {
 			final EObject innerExpr = expr.getExpr();
 			if (innerExpr instanceof GipsNodeAttributeExpr) {
 				exprEval = getEvalTypeFromNodeAttrExpr((GipsNodeAttributeExpr) innerExpr);
-			} else if (innerExpr instanceof GipsContextOperationExpression) {
-				exprEval = getEvalTypeFromContextOpExpr((GipsContextOperationExpression) innerExpr);
+			} else if (innerExpr instanceof GipsVariableOperationExpression) {
+				exprEval = getEvalTypeFromContextOpExpr((GipsVariableOperationExpression) innerExpr);
 			} else if (innerExpr instanceof GipsFeatureExpr) {
 				exprEval = getEvalTypeFromFeatureExpr((GipsFeatureExpr) innerExpr);
 			}
@@ -1752,7 +1752,7 @@ public class GipslValidator extends AbstractGipslValidator {
 		return exprEval;
 	}
 
-	public EvalType getEvalTypeFromContextOpExpr(final GipsContextOperationExpression expr) {
+	public EvalType getEvalTypeFromContextOpExpr(final GipsVariableOperationExpression expr) {
 		if (expr instanceof GipsMappingCheckValue) {
 			return EvalType.BOOLEAN;
 		} else if (expr instanceof GipsMappingValue) {


### PR DESCRIPTION
It should now be possible to access mapping variable values explicitly by using the .value() operator.
-> Enabled for iterator variables of mapping collections within sum expressions
-> Enabled for self references within mapping contexts