### PR TITLE
Feature/gt imports

### DIFF
--- a/org.emoflon.gips.gipsl.ui/META-INF/MANIFEST.MF
+++ b/org.emoflon.gips.gipsl.ui/META-INF/MANIFEST.MF
@@ -33,6 +33,7 @@ Export-Package: org.emoflon.gips.gipsl.ui,
  org.emoflon.gips.gipsl.ui.contentassist,
  org.emoflon.gips.gipsl.ui.internal,
  org.emoflon.gips.gipsl.ui.labeling,
+ org.emoflon.gips.gipsl.ui.nature,
  org.emoflon.gips.gipsl.ui.outline,
  org.emoflon.gips.gipsl.ui.quickfix,
  org.emoflon.gips.gipsl.ui.wizard

--- a/org.emoflon.gips.gipsl.ui/plugin.xml
+++ b/org.emoflon.gips.gipsl.ui/plugin.xml
@@ -466,4 +466,17 @@
           class="org.emoflon.gips.gipsl.ui.visualization.GipsVisualizer">
     </diagram_text_provider>
  </extension>
+ <extension
+       id="gipsNature"
+       name="GIPS Nature"
+       point="org.eclipse.core.resources.natures">
+    <runtime>
+       <run
+             class="org.emoflon.gips.gipsl.ui.nature.GIPSNature">
+       </run>
+    </runtime>
+    <builder
+          id="org.emoflon.gips.gipsl.generator">
+    </builder>
+ </extension>
 </plugin>

--- a/org.emoflon.gips.gipsl.ui/src/org/emoflon/gips/gipsl/ui/contentassist/GipslProposalProvider.java
+++ b/org.emoflon.gips.gipsl.ui/src/org/emoflon/gips/gipsl/ui/contentassist/GipslProposalProvider.java
@@ -40,7 +40,7 @@ public class GipslProposalProvider extends AbstractGipslProposalProvider {
 			ICompletionProposalAcceptor acceptor) {
 		super.completePackage_Name(model, assignment, context, acceptor);
 
-		IProject currentProject = GipslScopeContextUtil.getCurrentProject(null);
+		IProject currentProject = GipslScopeContextUtil.getCurrentProject(model.eResource());
 
 		String[] lines = context.getCurrentNode().getText().split("\n");
 		lines = lines[0].split("\r");
@@ -103,7 +103,7 @@ public class GipslProposalProvider extends AbstractGipslProposalProvider {
 	public void completeImportedPattern_File(EObject model, Assignment assignment, ContentAssistContext context,
 			ICompletionProposalAcceptor acceptor) {
 		super.completeImportedPattern_File(model, assignment, context, acceptor);
-		IProject currentProject = GipslScopeContextUtil.getCurrentProject(null);
+		IProject currentProject = GipslScopeContextUtil.getCurrentProject(model.eResource());
 		String currentFile = model.eResource().getURI().toString().replace("platform:/resource/", "")
 				.replace(currentProject.getName(), "");
 		currentFile = currentProject.getLocation().toPortableString() + currentFile;

--- a/org.emoflon.gips.gipsl.ui/src/org/emoflon/gips/gipsl/ui/nature/GIPSNature.java
+++ b/org.emoflon.gips.gipsl.ui/src/org/emoflon/gips/gipsl/ui/nature/GIPSNature.java
@@ -1,0 +1,91 @@
+package org.emoflon.gips.gipsl.ui.nature;
+
+import java.util.ArrayList;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.IProjectNature;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IStatus;
+
+public class GIPSNature implements IProjectNature {
+
+	public static final String NATURE_ID = "org.emoflon.gips.gipsl.ui.gipsNature";
+
+	private IProject project;
+
+	@Override
+	public void configure() throws CoreException {
+		IProjectDescription description = project.getDescription();
+		String[] natures = description.getNatureIds();
+		String[] newNatures;
+		int idx = -1;
+		for (int i = 0; i < natures.length; i++) {
+			if (natures[i].equals(NATURE_ID)) {
+				idx = i;
+				break;
+			}
+		}
+
+		if (idx >= 0) {
+			natures[idx] = natures[0];
+			natures[0] = NATURE_ID;
+			newNatures = new String[natures.length];
+			System.arraycopy(natures, 0, newNatures, 0, natures.length);
+		} else {
+			newNatures = new String[natures.length + 1];
+			System.arraycopy(natures, 0, newNatures, 1, natures.length);
+			newNatures[0] = NATURE_ID;
+		}
+
+		// validate the natures
+		IWorkspace workspace = ResourcesPlugin.getWorkspace();
+		IStatus status = workspace.validateNatureSet(newNatures);
+
+		// only apply new nature, if the status is ok
+		if (status.getCode() == IStatus.OK) {
+			description.setNatureIds(newNatures);
+			project.setDescription(description, null);
+		}
+
+	}
+
+	@Override
+	public void deconfigure() throws CoreException {
+		IProjectDescription description = project.getDescription();
+		String[] natures = description.getNatureIds();
+		ArrayList<String> newNatures = new ArrayList<>();
+		for (String nature : natures) {
+			if (nature.equals(NATURE_ID))
+				continue;
+
+			newNatures.add(nature);
+		}
+
+		String[] natures2 = new String[newNatures.size()];
+		newNatures.toArray(natures2);
+
+		// validate the natures
+		IWorkspace workspace = ResourcesPlugin.getWorkspace();
+		IStatus status = workspace.validateNatureSet(natures2);
+
+		// only apply new nature, if the status is ok
+		if (status.getCode() == IStatus.OK) {
+			description.setNatureIds(natures2);
+			project.setDescription(description, null);
+		}
+	}
+
+	@Override
+	public IProject getProject() {
+		return project;
+	}
+
+	@Override
+	public void setProject(IProject project) {
+		this.project = project;
+	}
+
+}

--- a/org.emoflon.gips.gipsl.ui/src/org/emoflon/gips/gipsl/ui/wizard/GipslProjectTemplateProvider.xtend
+++ b/org.emoflon.gips.gipsl.ui/src/org/emoflon/gips/gipsl/ui/wizard/GipslProjectTemplateProvider.xtend
@@ -55,6 +55,7 @@ final class HelloWorldProject {
 			builderIds += #[JavaCore.BUILDER_ID, XtextProjectHelper.BUILDER_ID]
 			folders += "src"
 			addFile('''src/«path»/Model.gipsl''', '''
+				package "«path»"
 				import "http://www.eclipse.org/emf/2002/Ecore"
 				// import a metamodel here
 				

--- a/org.emoflon.gips.gipsl.ui/src/org/emoflon/gips/gipsl/ui/wizard/GipslProjectTemplateProvider.xtend
+++ b/org.emoflon.gips.gipsl.ui/src/org/emoflon/gips/gipsl/ui/wizard/GipslProjectTemplateProvider.xtend
@@ -13,6 +13,7 @@ import org.eclipse.xtext.ui.wizard.template.IProjectTemplateProvider
 import org.eclipse.xtext.ui.wizard.template.ProjectTemplate
 
 import static org.eclipse.core.runtime.IStatus.*
+import org.emoflon.gips.gipsl.ui.nature.GIPSNature
 
 /**
  * Create a list with all project templates to be shown in the template new project wizard.
@@ -50,12 +51,12 @@ final class HelloWorldProject {
 		generator.generate(new PluginProjectFactory => [
 			projectName = projectInfo.projectName
 			location = projectInfo.locationPath
-			projectNatures += #[JavaCore.NATURE_ID, "org.eclipse.pde.PluginNature", XtextProjectHelper.NATURE_ID]
+			projectNatures += #[GIPSNature.NATURE_ID, JavaCore.NATURE_ID, "org.eclipse.pde.PluginNature", XtextProjectHelper.NATURE_ID]
 			builderIds += #[JavaCore.BUILDER_ID, XtextProjectHelper.BUILDER_ID]
 			folders += "src"
 			addFile('''src/«path»/Model.gipsl''', '''
 				import "http://www.eclipse.org/emf/2002/Ecore"
-				// ^import a metamodel here
+				// import a metamodel here
 				
 				config {  
 					solver := GUROBI [home:="fu", license:="bar"];

--- a/org.emoflon.gips.gipsl/META-INF/MANIFEST.MF
+++ b/org.emoflon.gips.gipsl/META-INF/MANIFEST.MF
@@ -17,7 +17,8 @@ Require-Bundle: org.eclipse.xtext,
  org.emoflon.ibex.gt.editor;bundle-version="1.1.0",
  org.emoflon.gips.intermediate;bundle-version="0.1.0",
  org.eclipse.core.resources,
- org.eclipse.core.runtime;bundle-version="3.23.0"
+ org.eclipse.core.runtime;bundle-version="3.23.0",
+ org.eclipse.ui.workbench
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: org.emoflon.gips.gipsl.parser.antlr,
  org.emoflon.gips.gipsl.serializer,

--- a/org.emoflon.gips.gipsl/META-INF/MANIFEST.MF
+++ b/org.emoflon.gips.gipsl/META-INF/MANIFEST.MF
@@ -6,7 +6,8 @@ Bundle-Vendor: Real-Time Systems Lab - TU Darmstadt
 Bundle-Version: 1.0.0.qualifier
 Bundle-SymbolicName: org.emoflon.gips.gipsl; singleton:=true
 Bundle-ActivationPolicy: lazy
-Require-Bundle: org.eclipse.xtext,
+Require-Bundle: org.eclipse.swt,
+ org.eclipse.xtext,
  org.eclipse.xtext.xbase,
  org.eclipse.equinox.common;bundle-version="3.5.0",
  org.eclipse.emf.ecore,

--- a/org.emoflon.gips.gipsl/model/generated/Gipsl.ecore
+++ b/org.emoflon.gips.gipsl/model/generated/Gipsl.ecore
@@ -2,6 +2,8 @@
 <ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="gipsl" nsURI="http://www.emoflon.org/gips/gipsl/Gipsl" nsPrefix="gipsl">
   <eClassifiers xsi:type="ecore:EClass" name="EditorGTFile" eSuperTypes="platform:/resource/org.emoflon.ibex.gt.editor/model/generated/GT.ecore#//EditorGTFile">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="importedPattern" upperBound="-1"
+        eType="#//ImportedPattern" containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="config" eType="#//GipsConfig"
         containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="mappings" upperBound="-1"
@@ -32,6 +34,10 @@
     <eLiterals name="GUROBI" literal="GUROBI"/>
     <eLiterals name="GLPK" value="1" literal="GLPK"/>
     <eLiterals name="CPLEX" value="2" literal="CPLEX"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ImportedPattern">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="file" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="pattern" eType="ecore:EClass platform:/resource/org.emoflon.ibex.gt.editor/model/generated/GT.ecore#//EditorPattern"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="GipsMapping">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="name" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>

--- a/org.emoflon.gips.gipsl/model/generated/Gipsl.ecore
+++ b/org.emoflon.gips.gipsl/model/generated/Gipsl.ecore
@@ -2,6 +2,8 @@
 <ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="gipsl" nsURI="http://www.emoflon.org/gips/gipsl/Gipsl" nsPrefix="gipsl">
   <eClassifiers xsi:type="ecore:EClass" name="EditorGTFile" eSuperTypes="platform:/resource/org.emoflon.ibex.gt.editor/model/generated/GT.ecore#//EditorGTFile">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="package" eType="#//Package"
+        containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="importedPattern" upperBound="-1"
         eType="#//ImportedPattern" containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="config" eType="#//GipsConfig"
@@ -14,6 +16,13 @@
         eType="#//GipsObjective" containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="globalObjective" eType="#//GipsGlobalObjective"
         containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Package">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="name" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ImportedPattern">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="file" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="pattern" eType="ecore:EClass platform:/resource/org.emoflon.ibex.gt.editor/model/generated/GT.ecore#//EditorPattern"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="GipsConfig">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="solver" eType="#//SolverType"/>
@@ -34,10 +43,6 @@
     <eLiterals name="GUROBI" literal="GUROBI"/>
     <eLiterals name="GLPK" value="1" literal="GLPK"/>
     <eLiterals name="CPLEX" value="2" literal="CPLEX"/>
-  </eClassifiers>
-  <eClassifiers xsi:type="ecore:EClass" name="ImportedPattern">
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="file" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="pattern" eType="ecore:EClass platform:/resource/org.emoflon.ibex.gt.editor/model/generated/GT.ecore#//EditorPattern"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="GipsMapping">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="name" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>

--- a/org.emoflon.gips.gipsl/model/generated/Gipsl.genmodel
+++ b/org.emoflon.gips.gipsl/model/generated/Gipsl.genmodel
@@ -65,12 +65,20 @@
       <genEnumLiterals ecoreEnumLiteral="Gipsl.ecore#//GipsStreamNoArgOperator/COUNT"/>
     </genEnums>
     <genClasses ecoreClass="Gipsl.ecore#//EditorGTFile">
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Gipsl.ecore#//EditorGTFile/package"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Gipsl.ecore#//EditorGTFile/importedPattern"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Gipsl.ecore#//EditorGTFile/config"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Gipsl.ecore#//EditorGTFile/mappings"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Gipsl.ecore#//EditorGTFile/constraints"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Gipsl.ecore#//EditorGTFile/objectives"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Gipsl.ecore#//EditorGTFile/globalObjective"/>
+    </genClasses>
+    <genClasses ecoreClass="Gipsl.ecore#//Package">
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Gipsl.ecore#//Package/name"/>
+    </genClasses>
+    <genClasses ecoreClass="Gipsl.ecore#//ImportedPattern">
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Gipsl.ecore#//ImportedPattern/file"/>
+      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference Gipsl.ecore#//ImportedPattern/pattern"/>
     </genClasses>
     <genClasses ecoreClass="Gipsl.ecore#//GipsConfig">
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Gipsl.ecore#//GipsConfig/solver"/>
@@ -86,10 +94,6 @@
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Gipsl.ecore#//GipsConfig/enableDebugOutput"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Gipsl.ecore#//GipsConfig/enableTolernace"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Gipsl.ecore#//GipsConfig/tolerance"/>
-    </genClasses>
-    <genClasses ecoreClass="Gipsl.ecore#//ImportedPattern">
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Gipsl.ecore#//ImportedPattern/file"/>
-      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference Gipsl.ecore#//ImportedPattern/pattern"/>
     </genClasses>
     <genClasses ecoreClass="Gipsl.ecore#//GipsMapping">
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Gipsl.ecore#//GipsMapping/name"/>

--- a/org.emoflon.gips.gipsl/model/generated/Gipsl.genmodel
+++ b/org.emoflon.gips.gipsl/model/generated/Gipsl.genmodel
@@ -65,6 +65,7 @@
       <genEnumLiterals ecoreEnumLiteral="Gipsl.ecore#//GipsStreamNoArgOperator/COUNT"/>
     </genEnums>
     <genClasses ecoreClass="Gipsl.ecore#//EditorGTFile">
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Gipsl.ecore#//EditorGTFile/importedPattern"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Gipsl.ecore#//EditorGTFile/config"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Gipsl.ecore#//EditorGTFile/mappings"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Gipsl.ecore#//EditorGTFile/constraints"/>
@@ -85,6 +86,10 @@
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Gipsl.ecore#//GipsConfig/enableDebugOutput"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Gipsl.ecore#//GipsConfig/enableTolernace"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Gipsl.ecore#//GipsConfig/tolerance"/>
+    </genClasses>
+    <genClasses ecoreClass="Gipsl.ecore#//ImportedPattern">
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Gipsl.ecore#//ImportedPattern/file"/>
+      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference Gipsl.ecore#//ImportedPattern/pattern"/>
     </genClasses>
     <genClasses ecoreClass="Gipsl.ecore#//GipsMapping">
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Gipsl.ecore#//GipsMapping/name"/>

--- a/org.emoflon.gips.gipsl/src/org/emoflon/gips/gipsl/Gipsl.xtext
+++ b/org.emoflon.gips.gipsl/src/org/emoflon/gips/gipsl/Gipsl.xtext
@@ -6,8 +6,9 @@ import "http://www.emoflon.org/ibex/gt/editor/GT" as GT
 generate gipsl "http://www.emoflon.org/gips/gipsl/Gipsl"
 
 @Override 
-EditorGTFile: {EditorGTFile} 
+EditorGTFile: {EditorGTFile}
 	(imports+=EditorImport)*
+	(importedPattern+=ImportedPattern)*
 	config = GipsConfig
   	(patterns+=EditorPattern |
   	conditions+=EditorCondition |
@@ -31,6 +32,10 @@ GipsConfig : {GipsConfig}
 
 enum SolverType:
 	GUROBI='GUROBI' | GLPK='GLPK' | CPLEX='CPLEX'
+;
+
+ImportedPattern : 
+	'from' file = GipsStringLiteral 'import' pattern = [GT::EditorPattern|ID]
 ;
 
 GipsMapping :

--- a/org.emoflon.gips.gipsl/src/org/emoflon/gips/gipsl/Gipsl.xtext
+++ b/org.emoflon.gips.gipsl/src/org/emoflon/gips/gipsl/Gipsl.xtext
@@ -7,6 +7,7 @@ generate gipsl "http://www.emoflon.org/gips/gipsl/Gipsl"
 
 @Override 
 EditorGTFile: {EditorGTFile}
+	package = Package
 	(imports+=EditorImport)*
 	(importedPattern+=ImportedPattern)*
 	config = GipsConfig
@@ -16,6 +17,14 @@ EditorGTFile: {EditorGTFile}
   	constraints += GipsConstraint |
   	objectives += GipsObjective)*
   	(globalObjective = GipsGlobalObjective)?	
+;
+
+Package: 
+	'package' name=GipsStringLiteral
+;
+
+ImportedPattern : 
+	'from' file = GipsStringLiteral 'import' pattern = [GT::EditorPattern|ID]
 ;
 
 GipsConfig : {GipsConfig}
@@ -32,10 +41,6 @@ GipsConfig : {GipsConfig}
 
 enum SolverType:
 	GUROBI='GUROBI' | GLPK='GLPK' | CPLEX='CPLEX'
-;
-
-ImportedPattern : 
-	'from' file = GipsStringLiteral 'import' pattern = [GT::EditorPattern|ID]
 ;
 
 GipsMapping :

--- a/org.emoflon.gips.gipsl/src/org/emoflon/gips/gipsl/scoping/GipslScopeContextUtil.java
+++ b/org.emoflon.gips.gipsl/src/org/emoflon/gips/gipsl/scoping/GipslScopeContextUtil.java
@@ -1,5 +1,7 @@
 package org.emoflon.gips.gipsl.scoping;
 
+import java.io.File;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -47,6 +49,7 @@ import org.emoflon.gips.gipsl.gipsl.GipsTypeCast;
 import org.emoflon.gips.gipsl.gipsl.GipsTypeContext;
 import org.emoflon.gips.gipsl.gipsl.GipsUnaryArithmeticExpr;
 import org.emoflon.gips.gipsl.gipsl.GipslPackage;
+import org.emoflon.gips.gipsl.gipsl.ImportedPattern;
 import org.emoflon.gips.gipsl.gipsl.impl.GipsConstraintImpl;
 import org.emoflon.gips.gipsl.gipsl.impl.GipsContainsImpl;
 import org.emoflon.gips.gipsl.gipsl.impl.GipsContextExprImpl;
@@ -60,6 +63,14 @@ import org.emoflon.gips.gipsl.gipsl.impl.GipsStreamSetImpl;
 import org.emoflon.gips.gipsl.gipsl.impl.GipsTypeAttributeExprImpl;
 
 public final class GipslScopeContextUtil {
+
+	public static boolean isPatternImportUri(final EObject context, final EReference reference) {
+		return context instanceof ImportedPattern && reference == GipslPackage.Literals.IMPORTED_PATTERN__FILE;
+	}
+
+	public static boolean isPatternImportPattern(final EObject context, final EReference reference) {
+		return context instanceof ImportedPattern && reference == GipslPackage.Literals.IMPORTED_PATTERN__PATTERN;
+	}
 
 	public static boolean isGipsMapping(final EObject context, final EReference reference) {
 		return context instanceof GipsMapping;
@@ -380,6 +391,22 @@ public final class GipslScopeContextUtil {
 		}
 
 		return mappings;
+	}
+
+	public static void gatherGTFiles(Collection<File> gtFiles, File root) {
+		if (root.isDirectory() && root.exists()) {
+			for (File subFile : root.listFiles()) {
+				gatherGTFiles(gtFiles, subFile);
+			}
+			return;
+		} else if (!root.isDirectory() && root.exists()) {
+			if (root.getName().endsWith(".gt")) {
+				gtFiles.add(root);
+				return;
+			}
+		} else {
+			return;
+		}
 	}
 
 }

--- a/org.emoflon.gips.gipsl/src/org/emoflon/gips/gipsl/scoping/GipslScopeContextUtil.java
+++ b/org.emoflon.gips.gipsl/src/org/emoflon/gips/gipsl/scoping/GipslScopeContextUtil.java
@@ -5,8 +5,15 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EReference;
+import org.eclipse.ui.IEditorInput;
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
 import org.emoflon.gips.gipsl.gipsl.GipsAndBoolExpr;
 import org.emoflon.gips.gipsl.gipsl.GipsArithmeticExpr;
 import org.emoflon.gips.gipsl.gipsl.GipsArithmeticLiteral;
@@ -393,20 +400,44 @@ public final class GipslScopeContextUtil {
 		return mappings;
 	}
 
-	public static void gatherGTFiles(Collection<File> gtFiles, File root) {
+	public static void gatherFilesWithEnding(Collection<File> gtFiles, File root, String ending, boolean ignoreBin) {
 		if (root.isDirectory() && root.exists()) {
+			if (ignoreBin && root.getName().equals("bin"))
+				return;
 			for (File subFile : root.listFiles()) {
-				gatherGTFiles(gtFiles, subFile);
+				gatherFilesWithEnding(gtFiles, subFile, ending, ignoreBin);
 			}
 			return;
 		} else if (!root.isDirectory() && root.exists()) {
-			if (root.getName().endsWith(".gt")) {
+			if (root.getName().endsWith(ending)) {
 				gtFiles.add(root);
 				return;
 			}
 		} else {
 			return;
 		}
+	}
+
+	public static IProject getCurrentProject() {
+		IProject project = null;
+		IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+		if (window != null) {
+			IWorkbenchPage activePage = window.getActivePage();
+			IEditorPart activeEditor = activePage.getActiveEditor();
+
+			if (activeEditor != null) {
+				IEditorInput input = activeEditor.getEditorInput();
+
+				project = input.getAdapter(IProject.class);
+				if (project == null) {
+					IResource resource = input.getAdapter(IResource.class);
+					if (resource != null) {
+						project = resource.getProject();
+					}
+				}
+			}
+		}
+		return project;
 	}
 
 }

--- a/org.emoflon.gips.gipsl/src/org/emoflon/gips/gipsl/scoping/GipslScopeProvider.java
+++ b/org.emoflon.gips.gipsl/src/org/emoflon/gips/gipsl/scoping/GipslScopeProvider.java
@@ -71,7 +71,7 @@ public class GipslScopeProvider extends AbstractGipslScopeProvider {
 			return getScopeInternal(context, reference);
 		} catch (Exception e) {
 			e.printStackTrace();
-			return super.getScope(context, reference);
+			return IScope.NULLSCOPE;
 		}
 	}
 
@@ -134,7 +134,13 @@ public class GipslScopeProvider extends AbstractGipslScopeProvider {
 		XtextResourceSet rs = new XtextResourceSet();
 		URI gtModelUri = URI.createFileURI(context.getFile().replace("\"", ""));
 
-		Resource resource = rs.getResource(gtModelUri, true);
+		Resource resource = null;
+		try {
+			resource = rs.getResource(gtModelUri, true);
+		} catch (Exception e) {
+			return IScope.NULLSCOPE;
+		}
+
 		EcoreUtil2.resolveLazyCrossReferences(resource, () -> false);
 		EObject gtModel = resource.getContents().get(0);
 		if (gtModel instanceof org.emoflon.ibex.gt.editor.gT.EditorGTFile gtFile) {
@@ -144,7 +150,7 @@ public class GipslScopeProvider extends AbstractGipslScopeProvider {
 			return Scopes.scopeFor(gipsFile.getPatterns().stream().filter(p -> !allPatterns.contains(p.getName()))
 					.collect(Collectors.toList()));
 		} else {
-			return super.getScope(context, reference);
+			return IScope.NULLSCOPE;
 		}
 
 	}

--- a/org.emoflon.gips.gipsl/src/org/emoflon/gips/gipsl/scoping/GipslScopeProvider.java
+++ b/org.emoflon.gips.gipsl/src/org/emoflon/gips/gipsl/scoping/GipslScopeProvider.java
@@ -125,7 +125,7 @@ public class GipslScopeProvider extends AbstractGipslScopeProvider {
 
 	private IScope scopeForImportedPatternPattern(ImportedPattern context, EReference reference) {
 		if (context.getFile() == null || context.getFile().isBlank())
-			return super.getScope(context, reference);
+			return IScope.NULLSCOPE;
 
 		Set<String> allPatterns = new HashSet<>();
 		EditorGTFile currentFile = GTEditorPatternUtils.getContainer(context, EditorGTFileImpl.class);
@@ -161,8 +161,7 @@ public class GipslScopeProvider extends AbstractGipslScopeProvider {
 	}
 
 	public IScope scopeForGipsMapping(GipsMapping context, EReference reference) {
-		EditorGTFile editorFile = GTEditorPatternUtils.getContainer(context, EditorGTFileImpl.class);
-		return Scopes.scopeFor(editorFile.getPatterns());
+		return Scopes.scopeFor(GipslScopeContextUtil.getAllEditorPatterns(context));
 	}
 
 	public IScope scopeForGipsMappingContext(GipsMappingContext context, EReference reference) {
@@ -204,7 +203,7 @@ public class GipslScopeProvider extends AbstractGipslScopeProvider {
 			if (parentAlt != null) {
 				contextType = parentAlt.getContext();
 			} else {
-				return super.getScope(context, reference);
+				return IScope.NULLSCOPE;
 			}
 		}
 
@@ -219,7 +218,7 @@ public class GipslScopeProvider extends AbstractGipslScopeProvider {
 					.filter(node -> !node.isLocal() && node.getOperator() != EditorOperator.CREATE)
 					.collect(Collectors.toList()));
 		} else {
-			return super.getScope(context, reference);
+			return IScope.NULLSCOPE;
 		}
 	}
 
@@ -228,7 +227,7 @@ public class GipslScopeProvider extends AbstractGipslScopeProvider {
 		Set<Class<?>> classes = Set.of(GipsStreamSetImpl.class, GipsStreamArithmeticImpl.class);
 		EObject parent = (EObject) GipslScopeContextUtil.getContainer(context, classes);
 		if (parent == null) {
-			return super.getScope(context, reference);
+			return IScope.NULLSCOPE;
 		}
 
 		if (parent instanceof GipsStreamSet streamSet) {
@@ -243,7 +242,7 @@ public class GipslScopeProvider extends AbstractGipslScopeProvider {
 		Set<Class<?>> classes = Set.of(GipsStreamSetImpl.class, GipsStreamArithmeticImpl.class);
 		EObject parent = (EObject) GipslScopeContextUtil.getContainer(context, classes);
 		if (parent == null) {
-			return super.getScope(context, reference);
+			return IScope.NULLSCOPE;
 		}
 
 		if (parent instanceof GipsStreamSet streamSet) {
@@ -260,7 +259,7 @@ public class GipslScopeProvider extends AbstractGipslScopeProvider {
 				GipsStreamSetImpl.class, GipsSelectImpl.class, GipsStreamArithmeticImpl.class);
 		EObject parent = (EObject) GipslScopeContextUtil.getContainer(context, classes);
 		if (parent == null) {
-			return super.getScope(context, reference);
+			return IScope.NULLSCOPE;
 		}
 
 		while (parent != null) {
@@ -280,7 +279,7 @@ public class GipslScopeProvider extends AbstractGipslScopeProvider {
 							EClass clazz = (EClass) lit.getFeature().getEType();
 							return Scopes.scopeFor(clazz.getEAllStructuralFeatures());
 						} else {
-							return super.getScope(context, reference);
+							return IScope.NULLSCOPE;
 						}
 					} else if (contextExpr.getExpr() instanceof GipsFeatureExpr featExpr) {
 						GipsFeatureExpr expr = GipslScopeContextUtil.findLeafExpression(featExpr);
@@ -288,13 +287,13 @@ public class GipslScopeProvider extends AbstractGipslScopeProvider {
 							EClass clazz = (EClass) lit.getFeature().getEType();
 							return Scopes.scopeFor(clazz.getEAllStructuralFeatures());
 						} else {
-							return super.getScope(context, reference);
+							return IScope.NULLSCOPE;
 						}
 					} else {
-						return super.getScope(context, reference);
+						return IScope.NULLSCOPE;
 					}
 				} else {
-					return super.getScope(context, reference);
+					return IScope.NULLSCOPE;
 				}
 			} else if (parent instanceof GipsStreamNavigation nav) {
 				if (nav.getLeft() instanceof GipsSelect select) {
@@ -310,7 +309,7 @@ public class GipslScopeProvider extends AbstractGipslScopeProvider {
 		}
 
 		// TODO: For now we'll exit this gracefully if anything unexpected occurs
-		return super.getScope(context, reference);
+		return IScope.NULLSCOPE;
 	}
 
 	public IScope scopeForGipsSelect(GipsSelect context, EReference reference) {
@@ -322,7 +321,7 @@ public class GipslScopeProvider extends AbstractGipslScopeProvider {
 			// TODO: Deactivated for now, since we do not support rule inheritance in any
 			// meaningful way
 			// return Scopes.scopeFor(List.of(mapping.getMapping().getRule()));
-			return super.getScope(context, reference);
+			return IScope.NULLSCOPE;
 		} else if (parent instanceof GipsTypeAttributeExpr typeExpr) {
 			EditorGTFile editorFile = GTEditorPatternUtils.getContainer(context, EditorGTFileImpl.class);
 			return Scopes.scopeFor(GTEditorModelUtils.getClasses(editorFile).stream()
@@ -337,7 +336,7 @@ public class GipslScopeProvider extends AbstractGipslScopeProvider {
 						return Scopes.scopeFor(GTEditorModelUtils.getClasses(editorFile).stream()
 								.filter(c -> c.getEAllSuperTypes().contains(clazz)).collect(Collectors.toSet()));
 					} else {
-						return super.getScope(context, reference);
+						return IScope.NULLSCOPE;
 					}
 				} else if (contextExpr.getExpr() instanceof GipsFeatureExpr featExpr) {
 					GipsFeatureExpr expr = GipslScopeContextUtil.findLeafExpression(featExpr);
@@ -347,16 +346,16 @@ public class GipslScopeProvider extends AbstractGipslScopeProvider {
 						return Scopes.scopeFor(GTEditorModelUtils.getClasses(editorFile).stream()
 								.filter(c -> c.getEAllSuperTypes().contains(clazz)).collect(Collectors.toSet()));
 					} else {
-						return super.getScope(context, reference);
+						return IScope.NULLSCOPE;
 					}
 				} else {
-					return super.getScope(context, reference);
+					return IScope.NULLSCOPE;
 				}
 			} else {
-				return super.getScope(context, reference);
+				return IScope.NULLSCOPE;
 			}
 		} else {
-			return super.getScope(context, reference);
+			return IScope.NULLSCOPE;
 		}
 	}
 
@@ -376,14 +375,14 @@ public class GipslScopeProvider extends AbstractGipslScopeProvider {
 				if (parentAlt != null) {
 					contextType = parentAlt.getContext();
 				} else {
-					return super.getScope(context, reference);
+					return IScope.NULLSCOPE;
 				}
 			}
 
 			if (contextType instanceof GipsTypeContext typeContext && typeContext.getType() instanceof EClass type) {
 				return Scopes.scopeFor(type.getEAllStructuralFeatures());
 			} else {
-				return super.getScope(context, reference);
+				return IScope.NULLSCOPE;
 			}
 		} else {
 			return Scopes.scopeFor(context.getTypeCast().getType().getEAllStructuralFeatures());
@@ -411,7 +410,7 @@ public class GipslScopeProvider extends AbstractGipslScopeProvider {
 				if (rootAlt != null) {
 					contextType = rootAlt.getContext();
 				} else {
-					return super.getScope(context, reference);
+					return IScope.NULLSCOPE;
 				}
 			}
 
@@ -426,7 +425,7 @@ public class GipslScopeProvider extends AbstractGipslScopeProvider {
 						.filter(node -> !node.isLocal() && node.getOperator() != EditorOperator.CREATE)
 						.collect(Collectors.toList()));
 			} else {
-				return super.getScope(context, reference);
+				return IScope.NULLSCOPE;
 			}
 		} else if (context.eContainer() instanceof GipsLambdaAttributeExpression lambda) {
 			return scopeForGipsLambdaAttributeExpression(lambda, reference);
@@ -446,7 +445,7 @@ public class GipslScopeProvider extends AbstractGipslScopeProvider {
 			}
 
 		} else {
-			return super.getScope(context, reference);
+			return IScope.NULLSCOPE;
 		}
 	}
 
@@ -468,7 +467,7 @@ public class GipslScopeProvider extends AbstractGipslScopeProvider {
 					if (rootAlt != null) {
 						contextType = rootAlt.getContext();
 					} else {
-						return super.getScope(context, reference);
+						return IScope.NULLSCOPE;
 					}
 				}
 
@@ -476,7 +475,7 @@ public class GipslScopeProvider extends AbstractGipslScopeProvider {
 						&& typeContext.getType() instanceof EClass type) {
 					return Scopes.scopeFor(type.getEAllStructuralFeatures());
 				} else {
-					return super.getScope(context, reference);
+					return IScope.NULLSCOPE;
 				}
 			} else {
 				return Scopes.scopeFor(contextExpr.getTypeCast().getType().getEAllStructuralFeatures());
@@ -504,7 +503,7 @@ public class GipslScopeProvider extends AbstractGipslScopeProvider {
 							if (rootAlt != null) {
 								contextType = rootAlt.getContext();
 							} else {
-								return super.getScope(context, reference);
+								return IScope.NULLSCOPE;
 							}
 						}
 
@@ -512,7 +511,7 @@ public class GipslScopeProvider extends AbstractGipslScopeProvider {
 								&& typeContext.getType() instanceof EClass type) {
 							return Scopes.scopeFor(type.getEAllStructuralFeatures());
 						} else {
-							return super.getScope(context, reference);
+							return IScope.NULLSCOPE;
 						}
 					} else {
 						return Scopes.scopeFor(contextExpr.getTypeCast().getType().getEAllStructuralFeatures());
@@ -530,7 +529,7 @@ public class GipslScopeProvider extends AbstractGipslScopeProvider {
 						}
 
 					} else {
-						return super.getScope(context, reference);
+						return IScope.NULLSCOPE;
 					}
 				}
 			} else {
@@ -541,7 +540,7 @@ public class GipslScopeProvider extends AbstractGipslScopeProvider {
 						return Scopes.scopeFor(parentFeature.getTypeCast().getType().getEAllStructuralFeatures());
 					}
 				} else {
-					return super.getScope(context, reference);
+					return IScope.NULLSCOPE;
 				}
 			}
 
@@ -558,14 +557,14 @@ public class GipslScopeProvider extends AbstractGipslScopeProvider {
 			} else if (root instanceof GipsObjectiveImpl obj) {
 				contextType = obj.getContext();
 			} else {
-				return super.getScope(context, reference);
+				return IScope.NULLSCOPE;
 			}
 			if (contextType instanceof GipsTypeContext type && type.getType() instanceof EClass clazz) {
 				EditorGTFile editorFile = GTEditorPatternUtils.getContainer(context, EditorGTFileImpl.class);
 				return Scopes.scopeFor(GTEditorModelUtils.getClasses(editorFile).stream()
 						.filter(c -> c.getEAllSuperTypes().contains(clazz)).collect(Collectors.toSet()));
 			} else {
-				return super.getScope(context, reference);
+				return IScope.NULLSCOPE;
 			}
 		} else if (context.eContainer() instanceof GipsNodeAttributeExpr atrExpr) {
 			EditorGTFile editorFile = GTEditorPatternUtils.getContainer(context, EditorGTFileImpl.class);
@@ -579,10 +578,10 @@ public class GipslScopeProvider extends AbstractGipslScopeProvider {
 						.filter(c -> c.getEAllSuperTypes().contains(lit.getFeature().getEType()))
 						.collect(Collectors.toSet()));
 			} else {
-				return super.getScope(context, reference);
+				return IScope.NULLSCOPE;
 			}
 		} else {
-			return super.getScope(context, reference);
+			return IScope.NULLSCOPE;
 		}
 	}
 

--- a/org.emoflon.gips.gipsl/src/org/emoflon/gips/gipsl/scoping/GipslScopeProvider.java
+++ b/org.emoflon.gips.gipsl/src/org/emoflon/gips/gipsl/scoping/GipslScopeProvider.java
@@ -156,8 +156,7 @@ public class GipslScopeProvider extends AbstractGipslScopeProvider {
 	}
 
 	private IScope scopeForGipsPatternContext(GipsPatternContext context, EReference reference) {
-		EditorGTFile editorFile = GTEditorPatternUtils.getContainer(context, EditorGTFileImpl.class);
-		return Scopes.scopeFor(editorFile.getPatterns());
+		return Scopes.scopeFor(GipslScopeContextUtil.getAllEditorPatterns(context));
 	}
 
 	public IScope scopeForGipsMapping(GipsMapping context, EReference reference) {
@@ -189,8 +188,7 @@ public class GipslScopeProvider extends AbstractGipslScopeProvider {
 	}
 
 	private IScope scopeForGipsPatternAttributeExprMapping(GipsPatternAttributeExpr context, EReference reference) {
-		EditorGTFile editorFile = GTEditorPatternUtils.getContainer(context, EditorGTFileImpl.class);
-		return Scopes.scopeFor(editorFile.getPatterns());
+		return Scopes.scopeFor(GipslScopeContextUtil.getAllEditorPatterns(context));
 	}
 
 	public IScope scopeForGipsContextExprNode(GipsContextExpr context, EReference reference) {

--- a/org.emoflon.gips.gipsl/src/org/emoflon/gips/gipsl/validation/GipslValidator.java
+++ b/org.emoflon.gips.gipsl/src/org/emoflon/gips/gipsl/validation/GipslValidator.java
@@ -786,6 +786,8 @@ public class GipslValidator extends AbstractGipslValidator {
 				} else if (exprOp instanceof GipsTypeAttributeExpr typeExpr) {
 					return streamContainsMappingsCall(typeExpr.getExpr());
 				}
+			} else if (exprOp instanceof GipsObjectiveExpression) {
+				return false;
 			}
 		} else if (expr instanceof GipsProductArithmeticExpr) {
 			final GipsProductArithmeticExpr prodExpr = (GipsProductArithmeticExpr) expr;
@@ -1015,6 +1017,8 @@ public class GipslValidator extends AbstractGipslValidator {
 				throw new UnsupportedOperationException(
 						NOT_IMPLEMENTED_EXCEPTION_MESSAGE + ": <" + expr.eClass() + ">");
 			} else if (expr instanceof GipsConstant) {
+				return false;
+			} else if (expr instanceof GipsObjectiveExpression) {
 				return false;
 			}
 
@@ -1863,6 +1867,8 @@ public class GipslValidator extends AbstractGipslValidator {
 			}
 		} else if (expr instanceof GipsFeatureLit) {
 			final GipsFeatureLit lit = (GipsFeatureLit) expr;
+			if (lit.getFeature() == null)
+				return EvalType.ERROR;
 			final EClassifier ecl = lit.getFeature().getEType();
 
 			if (lit.getFeature().getUpperBound() == -1 || lit.getFeature().getUpperBound() > 1) {

--- a/org.emoflon.gips.gipsl/src/org/emoflon/gips/gipsl/validation/GipslValidator.java
+++ b/org.emoflon.gips.gipsl/src/org/emoflon/gips/gipsl/validation/GipslValidator.java
@@ -79,6 +79,7 @@ import org.emoflon.gips.gipsl.gipsl.GipsVariableOperationExpression;
 import org.emoflon.gips.gipsl.gipsl.GipslPackage;
 import org.emoflon.gips.gipsl.gipsl.GlobalContext;
 import org.emoflon.gips.gipsl.gipsl.ImportedPattern;
+import org.emoflon.gips.gipsl.gipsl.Package;
 import org.emoflon.gips.gipsl.gipsl.impl.EditorGTFileImpl;
 import org.emoflon.gips.gipsl.scoping.GipslScopeContextUtil;
 import org.emoflon.ibex.gt.editor.gT.EditorNode;
@@ -206,6 +207,46 @@ public class GipslValidator extends AbstractGipslValidator {
 		if (count != 1) {
 			error(String.format(PATTERN_NAME_MULTIPLE_DECLARATIONS_MESSAGE, pattern.getName(),
 					super.getTimes((int) count)), GTPackage.Literals.EDITOR_PATTERN__NAME, NAME_EXPECT_UNIQUE);
+		}
+
+	}
+
+	@Check
+	public void packageValid(Package pkg) {
+		if (pkg.getName() == null || pkg.getName().isBlank()) {
+			error("Package name must not be empty!", GipslPackage.Literals.PACKAGE__NAME);
+			return;
+		}
+
+		if (pkg.getName().contains(" ")) {
+			error("Package name may not contain any white spaces.", GipslPackage.Literals.PACKAGE__NAME);
+		}
+
+		if (pkg.getName().contains("\\")) {
+			error("Package name may not contain any slashes.", GipslPackage.Literals.PACKAGE__NAME);
+		}
+
+		if (pkg.getName().contains("/")) {
+			error("Package name may not contain any slashes.", GipslPackage.Literals.PACKAGE__NAME);
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		if (pkg.getName().chars().filter(c -> Character.isUpperCase(c)).map(c -> {
+			sb.append((char) c + " ");
+			return c;
+		}).findAny().isPresent()) {
+			error("Package name may not contain any upper case letters. The following illegal characters were found: "
+					+ sb.toString(), GipslPackage.Literals.PACKAGE__NAME);
+		}
+
+		if (pkg.getName().chars().filter(c -> !(Character.isLetter(c) || Character.isDigit(c) || c == '.' || c == '"'))
+				.map(c -> {
+					sb.append((char) c + " ");
+					return c;
+				}).findAny().isPresent()) {
+			error("Package name may not contain any characters other than lower case letters, digits or dots. The following illegal characters were found: "
+					+ sb.toString(), GipslPackage.Literals.PACKAGE__NAME);
 		}
 
 	}

--- a/org.emoflon.gips.gipsl/src/org/emoflon/gips/gipsl/validation/GipslValidator.java
+++ b/org.emoflon.gips.gipsl/src/org/emoflon/gips/gipsl/validation/GipslValidator.java
@@ -356,7 +356,7 @@ public class GipslValidator extends AbstractGipslValidator {
 			}
 		} else {
 			// 1. Case: package name
-			if (!currentImport.contains("/") || currentImport.contains("\\")) {
+			if (!(currentImport.contains("/") || currentImport.contains("\\"))) {
 				IProject currentProject = GipslScopeContextUtil.getCurrentProject(pattern.eResource());
 
 				String currentFile = pattern.eResource().getURI().toString().replace("platform:/resource/", "")
@@ -414,8 +414,16 @@ public class GipslValidator extends AbstractGipslValidator {
 			} else { // 2. Case: relative path
 				IProject currentProject = GipslScopeContextUtil.getCurrentProject(pattern.eResource());
 
-				String absolutePath = Paths.get(currentProject.getLocation().toPortableString())
-						.resolve(Paths.get(currentImport)).toString();
+				String absolutePath = null;
+				try {
+					absolutePath = Paths.get(currentProject.getLocation().toPortableString())
+							.resolve(Paths.get(currentImport)).toFile().getCanonicalPath();
+				} catch (IOException e1) {
+					error("Relative import URI <" + currentImport + "> is not resolvable.",
+							GipslPackage.Literals.IMPORTED_PATTERN__FILE);
+					return;
+				}
+
 				gtModelUri = URI.createFileURI(absolutePath);
 				try {
 					resource = rs.getResource(gtModelUri, true);

--- a/org.emoflon.gips.gipsl/src/org/emoflon/gips/gipsl/validation/GipslValidator.java
+++ b/org.emoflon.gips.gipsl/src/org/emoflon/gips/gipsl/validation/GipslValidator.java
@@ -75,8 +75,13 @@ import org.emoflon.gips.gipsl.gipsl.GipsUnaryArithmeticExpr;
 import org.emoflon.gips.gipsl.gipsl.GipsVariableOperationExpression;
 import org.emoflon.gips.gipsl.gipsl.GipslPackage;
 import org.emoflon.gips.gipsl.gipsl.GlobalContext;
+import org.emoflon.gips.gipsl.gipsl.ImportedPattern;
+import org.emoflon.gips.gipsl.gipsl.impl.EditorGTFileImpl;
 import org.emoflon.gips.gipsl.scoping.GipslScopeContextUtil;
 import org.emoflon.ibex.gt.editor.gT.EditorNode;
+import org.emoflon.ibex.gt.editor.gT.EditorPattern;
+import org.emoflon.ibex.gt.editor.gT.GTPackage;
+import org.emoflon.ibex.gt.editor.utils.GTEditorPatternUtils;
 
 /**
  * This class contains custom validation rules.
@@ -182,6 +187,41 @@ public class GipslValidator extends AbstractGipslValidator {
 	@Override
 	protected void handleExceptionDuringValidation(final Throwable targetException) throws RuntimeException {
 		targetException.printStackTrace();
+	}
+
+	/**
+	 * Pattern names must be unique.
+	 */
+	@Override
+	public void checkPatternNameUnique(EditorPattern pattern) {
+		EditorGTFile file = GTEditorPatternUtils.getContainer(pattern, EditorGTFileImpl.class);
+		long count = file.getPatterns().stream().filter(p -> p != null && p.getName() != null)
+				.filter(p -> p.getName().equals(pattern.getName())).count();
+		count += file.getImportedPattern().stream()
+				.filter(p -> p != null && p.getPattern() != null && p.getPattern().getName() != null)
+				.filter(p -> p.getPattern().getName().equals(pattern.getName())).count();
+		if (count != 1) {
+			error(String.format(PATTERN_NAME_MULTIPLE_DECLARATIONS_MESSAGE, pattern.getName(),
+					super.getTimes((int) count)), GTPackage.Literals.EDITOR_PATTERN__NAME, NAME_EXPECT_UNIQUE);
+		}
+
+	}
+
+	/**
+	 * Pattern names must be unique.
+	 */
+	@Check
+	public void checkImportNameUnique(ImportedPattern pattern) {
+		EditorGTFile file = GTEditorPatternUtils.getContainer(pattern, EditorGTFileImpl.class);
+		long count = file.getPatterns().stream().filter(p -> p != null && p.getName() != null)
+				.filter(p -> p.getName().equals(pattern.getPattern().getName())).count();
+		count += file.getImportedPattern().stream()
+				.filter(p -> p != null && p.getPattern() != null && p.getPattern().getName() != null)
+				.filter(p -> p.getPattern().getName().equals(pattern.getPattern().getName())).count();
+		if (count != 1) {
+			error(String.format(PATTERN_NAME_MULTIPLE_DECLARATIONS_MESSAGE, pattern.getPattern().getName(),
+					super.getTimes((int) count)), GipslPackage.Literals.IMPORTED_PATTERN__PATTERN, NAME_EXPECT_UNIQUE);
+		}
 	}
 
 	/**


### PR DESCRIPTION
-  Added the import feature, which allows the import of patterns or rules from other .gipsl or .gt files
-  Foreign imported patterns or rules can now be used as if they were defined within the current document
-  If patterns depend on other patterns transitively, they are imported as well
-  If required other metamodels are imported as well

### TODOS:
-  Automatically importing transitively required metamodels might lead to conflict with the imported metamodel of the current file. What to do if 2 unrelated metamodels are imported? How would an instance graph look like?
- Automatic import of transitively required patterns is pretty dumb at the moment. Basically everything from foreign files is imported indiscriminately. In the future only absolutely necessary patterns should be imported to avoid name conflicts
- What about static imports aka. name spaced imports?
- What about the deliberate import of all conents of foreign files?
- What about imports of foreign constraints, objectives, mappings etc.?
