### PR TITLE
Re-enables the validator and allows `self.value()` in mapping contexts

### DIFF
--- a/org.emoflon.gips.gipsl/src/org/emoflon/gips/gipsl/validation/GipslConstraintValidator.java
+++ b/org.emoflon.gips.gipsl/src/org/emoflon/gips/gipsl/validation/GipslConstraintValidator.java
@@ -258,8 +258,9 @@ public class GipslConstraintValidator {
 					if (streamContainsMappingsCall(conExpr.getStream())) {
 						return true;
 					}
-					return (conExpr.getExpr() instanceof GipsVariableOperationExpression
-							&& !(conExpr.getExpr() instanceof GipsMappingCheckValue));
+					// Access of type 'self.value()' in context 'mapping' is allowed because the
+					// transformation takes this into account
+					return false;
 				} else if (exprOp instanceof GipsLambdaAttributeExpression) {
 					// A GipsLambdaAttributeExpression can not contain a mappings call
 					return false;

--- a/org.emoflon.gips.gipsl/src/org/emoflon/gips/gipsl/validation/GipslValidator.java
+++ b/org.emoflon.gips.gipsl/src/org/emoflon/gips/gipsl/validation/GipslValidator.java
@@ -109,7 +109,7 @@ public class GipslValidator extends AbstractGipslValidator {
 	/**
 	 * Global switch to turn off the whole validation.
 	 */
-	static final boolean DISABLE_VALIDATOR = true;
+	static final boolean DISABLE_VALIDATOR = false;
 
 	/**
 	 * Instance of this class


### PR DESCRIPTION
Closes #43 and closes #102.

At least for me, with this PR, the validator is happy with all test projects of the test repository as well as all experimental examples (SDR + PTA) .