### PR TITLE
Hotfix: Prevent NPE in some edge cases of the `TypeIndexer`

### DIFF
--- a/org.emoflon.gips.core/src/org/emoflon/gips/core/TypeIndexer.java
+++ b/org.emoflon.gips.core/src/org/emoflon/gips/core/TypeIndexer.java
@@ -225,7 +225,10 @@ public class TypeIndexer {
 		Queue<EObject> frontier = new LinkedList<>();
 		current.eClass().getEAllContainments().forEach(ref -> {
 			if (ref.getUpperBound() == 1) {
-				frontier.add((EObject) current.eGet(ref));
+				// Check if EObject to add is null
+				if (current.eGet(ref) != null) {
+					frontier.add((EObject) current.eGet(ref));
+				}
 			} else {
 				frontier.addAll((Collection<? extends EObject>) current.eGet(ref));
 			}


### PR DESCRIPTION
In some edge cases, the `TypeIndexer` produced an NPE.

Example case:
- Metamodel with type `Root`
- `Root` has a reference of another type (e.g., `Subnode`) with multiplicity `0..1`
- In the instance object of `Root` the reference to `Subnode` is `null`

This fix (or another one for this bug) is necessary for our incremental P2P example.