### PR TITLE
Adds the missing eMoflon API termination call to the `GipsEngineAPI`

### DIFF
--- a/org.emoflon.gips.core/src/org/emoflon/gips/core/api/GipsEngineAPI.java
+++ b/org.emoflon.gips.core/src/org/emoflon/gips/core/api/GipsEngineAPI.java
@@ -104,6 +104,18 @@ public abstract class GipsEngineAPI<EMOFLON_APP extends GraphTransformationApp<E
 		return this.eMoflonAPI.getModel();
 	}
 
+	/**
+	 * Terminates the GipsEngine (super class) and the eMoflon::IBeX engine
+	 * (including the pattern matcher).
+	 */
+	public void terminate() {
+		// Terminate the GipsEngine
+		super.terminate();
+
+		// Terminate the eMoflon::IBeX engine (including HiPE)
+		this.getEMoflonAPI().terminate();
+	}
+
 	protected void setSolverConfig(final ILPConfig config) {
 		solverConfig = new ILPSolverConfig(config.isEnableTimeLimit(), config.getIlpTimeLimit(), //
 				config.isEnableRndSeed(), config.getIlpRndSeed(), //


### PR DESCRIPTION
Closes #141.