### PR TITLE
Bugfix: missing default value for GT rule parameter type `EString`

### DIFF
--- a/org.emoflon.gips.build/src/org/emoflon/gips/build/generator/GipsImportManager.java
+++ b/org.emoflon.gips.build/src/org/emoflon/gips/build/generator/GipsImportManager.java
@@ -255,7 +255,7 @@ public class GipsImportManager {
 		} else if (par.getType() == EcorePackage.Literals.EFLOAT || par.getType() == EcorePackage.Literals.EDOUBLE) {
 			return "0.0";
 		} else if (par.getType() == EcorePackage.Literals.ESTRING || par.getType() == EcorePackage.Literals.ECHAR) {
-			return "";
+			return "\"\"";
 		} else if (par.getType() == EcorePackage.Literals.EBOOLEAN) {
 			return "false";
 		} else {


### PR DESCRIPTION
+ Fixed a bug that occurred when parametrized patterns or rules were created that made use of EString parameters. In that case a suitable default value during the creation of the corresponding pattern/rule object was not properly generated and set.