### PR TITLE
Fixes: missing logicng dependency in updatesite build + missing metadata of project `org.emoflon.gips.intermediate`

### DIFF
--- a/org.emoflon.gips.core.dependencies/build.properties
+++ b/org.emoflon.gips.core.dependencies/build.properties
@@ -4,10 +4,10 @@ bin.includes = META-INF/,\
                lib/cplex-22.1.1.jar,\
                lib/gurobi-11.0.3.jar,\
                lib/gurobi-javadoc-11.0.3.jar,\
-               lib/logicng-2.5.0.jar,\
-               lib/logicng-2.5.0-javadoc.jar,\
-               lib/logicng-parser-j8-2.5.0.jar,\
-               lib/logicng-parser-j8-2.5.0-javadoc.jar,\
+               lib/logicng-2.6.0.jar,\
+               lib/logicng-2.6.0-javadoc.jar,\
+               lib/logicng-parser-j8-2.6.0.jar,\
+               lib/logicng-parser-j8-2.6.0-javadoc.jar,\
                lib/slf4j-api-2.0.16.jar,\
                lib/slf4j-api-2.0.16-javadoc.jar,\
                lib/oshi-core-6.6.5.jar,\

--- a/org.emoflon.gips.intermediate/META-INF/MANIFEST.MF
+++ b/org.emoflon.gips.intermediate/META-INF/MANIFEST.MF
@@ -1,11 +1,11 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: %pluginName
+Bundle-Name: org.emoflon.gips.intermediate
 Bundle-SymbolicName: org.emoflon.gips.intermediate;singleton:=true
 Automatic-Module-Name: org.emoflon.gips.intermediate
 Bundle-Version: 0.1.0.qualifier
 Bundle-ClassPath: .
-Bundle-Vendor: %providerName
+Bundle-Vendor: Real-Time Systems Lab - TU Darmstadt
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Export-Package: org.emoflon.gips.intermediate.GipsIntermediate,


### PR DESCRIPTION
Closes #174.