### PR TITLE
Adds an implicit conversion to `double` for all `recude(0.0, ...)` operations

### DIFF
--- a/org.emoflon.gips.build/src/org/emoflon/gips/build/generator/templates/ConstraintTemplate.xtend
+++ b/org.emoflon.gips.build/src/org/emoflon/gips/build/generator/templates/ConstraintTemplate.xtend
@@ -431,13 +431,13 @@ abstract class ConstraintTemplate <CONTEXT extends Constraint> extends Generator
 			return '''indexer.getObjectsOfType("«constExpr.type.type.name»").parallelStream()
 			.map(type -> («constExpr.type.type.name») type)
 			«getFilterExpr(constExpr.filter, ExpressionContext.constConstraint)»
-			.map(«getIteratorVariableName(constExpr)» -> «parseExpression(constExpr.expression, ExpressionContext.constConstraint)»)
+			.map(«getIteratorVariableName(constExpr)» -> 1.0 * «parseExpression(constExpr.expression, ExpressionContext.constConstraint)»)
 			.reduce(0.0, (sum, value) -> sum + value)'''
 		} else if(constExpr instanceof PatternSumExpression) {
 			imports.add(data.apiData.matchesPkg+"."+data.pattern2matchClassName.get(constExpr.pattern))
 			return '''engine.getEMoflonAPI().«constExpr.pattern.name»().findMatches(false).parallelStream()
 			«getFilterExpr(constExpr.filter, ExpressionContext.constConstraint)»
-			.map(«getIteratorVariableName(constExpr)» -> «parseExpression(constExpr.expression, ExpressionContext.constConstraint)»)
+			.map(«getIteratorVariableName(constExpr)» -> 1.0 * «parseExpression(constExpr.expression, ExpressionContext.constConstraint)»)
 			.reduce(0.0, (sum, value) -> sum + value)'''
 		} else if(constExpr instanceof ContextSumExpression) {
 			if(constExpr.context instanceof Mapping) {
@@ -445,12 +445,12 @@ abstract class ConstraintTemplate <CONTEXT extends Constraint> extends Generator
 			} else if(constExpr.context instanceof Pattern) {
 				return '''context.get«constExpr.node.name.toFirstUpper»().«parseFeatureExpression(constExpr.feature)».parallelStream()
 			«getFilterExpr(constExpr.filter, ExpressionContext.constConstraint)»
-			.map(«getIteratorVariableName(constExpr)» -> «parseExpression(constExpr.expression, ExpressionContext.constConstraint)»)
+			.map(«getIteratorVariableName(constExpr)» -> 1.0 * «parseExpression(constExpr.expression, ExpressionContext.constConstraint)»)
 			.reduce(0.0, (sum, value) -> sum + value)'''
 			} else if(constExpr.context instanceof Type) {
 				return '''context.«parseFeatureExpression(constExpr.feature)».stream()
 			«getFilterExpr(constExpr.filter, ExpressionContext.constConstraint)»
-			.map(«getIteratorVariableName(constExpr)» -> «parseExpression(constExpr.expression, ExpressionContext.constConstraint)»)
+			.map(«getIteratorVariableName(constExpr)» -> 1.0 * «parseExpression(constExpr.expression, ExpressionContext.constConstraint)»)
 			.reduce(0.0, (sum, value) -> sum + value)'''
 			} else {
 				throw new UnsupportedOperationException("Unknown context type.");
@@ -568,13 +568,13 @@ abstract class ConstraintTemplate <CONTEXT extends Constraint> extends Generator
 			return '''indexer.getObjectsOfType("«varExpr.type.type.name»").parallelStream()
 			.map(type -> («varExpr.type.type.name») type)
 			«getFilterExpr(varExpr.filter, ExpressionContext.varConstraint)»
-			.map(«getIteratorVariableName(varExpr)» -> «parseExpression(varExpr.expression, ExpressionContext.varConstraint)»)
+			.map(«getIteratorVariableName(varExpr)» -> 1.0 * «parseExpression(varExpr.expression, ExpressionContext.varConstraint)»)
 			.reduce(0.0, (sum, value) -> sum + value)'''
 		} else if(varExpr instanceof PatternSumExpression) {
 			imports.add(data.apiData.matchesPkg+"."+data.pattern2matchClassName.get(varExpr.pattern))
 			return '''engine.getEMoflonAPI().«varExpr.pattern.name»().findMatches(false).parallelStream()
 			«getFilterExpr(varExpr.filter, ExpressionContext.varConstraint)»
-			.map(«getIteratorVariableName(varExpr)» -> «parseExpression(varExpr.expression, ExpressionContext.varConstraint)»)
+			.map(«getIteratorVariableName(varExpr)» -> 1.0 * «parseExpression(varExpr.expression, ExpressionContext.varConstraint)»)
 			.reduce(0.0, (sum, value) -> sum + value)'''
 		} else if(varExpr instanceof ContextSumExpression) {
 			if(varExpr.context instanceof Mapping) {
@@ -582,12 +582,12 @@ abstract class ConstraintTemplate <CONTEXT extends Constraint> extends Generator
 			} else if(varExpr.context instanceof Pattern) {
 				return '''context.get«varExpr.node.name.toFirstUpper»().«parseFeatureExpression(varExpr.feature)».parallelStream()
 			«getFilterExpr(varExpr.filter, ExpressionContext.varConstraint)»
-			.map(«getIteratorVariableName(varExpr)» -> «parseExpression(varExpr.expression, ExpressionContext.varConstraint)»)
+			.map(«getIteratorVariableName(varExpr)» -> 1.0 * «parseExpression(varExpr.expression, ExpressionContext.varConstraint)»)
 			.reduce(0.0, (sum, value) -> sum + value)'''
 			} else if(varExpr.context instanceof Type) {
 				return '''context.«parseFeatureExpression(varExpr.feature)».stream()
 			«getFilterExpr(varExpr.filter, ExpressionContext.varConstraint)»
-			.map(«getIteratorVariableName(varExpr)» -> «parseExpression(varExpr.expression, ExpressionContext.varConstraint)»)
+			.map(«getIteratorVariableName(varExpr)» -> 1.0 * «parseExpression(varExpr.expression, ExpressionContext.varConstraint)»)
 			.reduce(0.0, (sum, value) -> sum + value)'''
 			} else {
 				throw new UnsupportedOperationException("Unknown context type.");

--- a/org.emoflon.gips.build/src/org/emoflon/gips/build/generator/templates/GlobalConstraintTemplate.xtend
+++ b/org.emoflon.gips.build/src/org/emoflon/gips/build/generator/templates/GlobalConstraintTemplate.xtend
@@ -413,7 +413,7 @@ protected List<ILPTerm> buildVariableLhs() {
 		return indexer.getObjectsOfType(«expr.type.type.EPackage.name».eINSTANCE.get«expr.type.type.name»()).parallelStream()
 			.map(type -> («expr.type.type.name») type)
 			«getFilterExpr(expr.filter, ExpressionContext.constStream)»
-			.map(type -> (double)«parseExpression(expr.expression, ExpressionContext.constConstraint)»)
+			.map(type -> 1.0 * «parseExpression(expr.expression, ExpressionContext.constConstraint)»)
 			.reduce(0.0, (sum, value) -> sum + value);
 	}
 		'''
@@ -454,7 +454,7 @@ protected List<ILPTerm> buildVariableLhs() {
 	protected double «methodName»(final List<ILPTerm> terms) {
 		return engine.getEMoflonAPI().«expr.pattern.name»().findMatches(false).parallelStream()
 			«getFilterExpr(expr.filter, ExpressionContext.constStream)»
-			.map(type -> (double)«parseExpression(expr.expression, ExpressionContext.constConstraint)»)
+			.map(type -> 1.0 * «parseExpression(expr.expression, ExpressionContext.constConstraint)»)
 			.reduce(0.0, (sum, value) -> sum + value);
 	}
 		'''

--- a/org.emoflon.gips.build/src/org/emoflon/gips/build/generator/templates/ObjectiveTemplate.xtend
+++ b/org.emoflon.gips.build/src/org/emoflon/gips/build/generator/templates/ObjectiveTemplate.xtend
@@ -457,13 +457,13 @@ abstract class ObjectiveTemplate <OBJECTIVE extends Objective> extends Generator
 			return '''indexer.getObjectsOfType("«constExpr.type.type.name»").parallelStream()
 			.map(type -> («constExpr.type.type.name») type)
 			«getFilterExpr(constExpr.filter, ExpressionContext.constConstraint)»
-			.map(«getIteratorVariableName(constExpr)» -> «parseExpression(constExpr.expression, ExpressionContext.constConstraint)»)
+			.map(«getIteratorVariableName(constExpr)» -> 1.0 * «parseExpression(constExpr.expression, ExpressionContext.constConstraint)»)
 			.reduce(0.0, (sum, value) -> sum + value)'''
 		} else if(constExpr instanceof PatternSumExpression) {
 			imports.add(data.apiData.matchesPkg+"."+data.pattern2matchClassName.get(constExpr.pattern))
 			return '''engine.getEMoflonAPI().«constExpr.pattern.name»().findMatches(false).parallelStream()
 			«getFilterExpr(constExpr.filter, ExpressionContext.constConstraint)»
-			.map(«getIteratorVariableName(constExpr)» -> «parseExpression(constExpr.expression, ExpressionContext.constConstraint)»)
+			.map(«getIteratorVariableName(constExpr)» -> 1.0 * «parseExpression(constExpr.expression, ExpressionContext.constConstraint)»)
 			.reduce(0.0, (sum, value) -> sum + value)'''
 		} else if(constExpr instanceof ContextSumExpression) {
 			if(constExpr.context instanceof Mapping) {
@@ -471,12 +471,12 @@ abstract class ObjectiveTemplate <OBJECTIVE extends Objective> extends Generator
 			} else if(constExpr.context instanceof Pattern) {
 				return '''context.get«constExpr.node.name.toFirstUpper»().«parseFeatureExpression(constExpr.feature)».stream()
 			«getFilterExpr(constExpr.filter, ExpressionContext.constConstraint)»
-			.map(«getIteratorVariableName(constExpr)» -> «parseExpression(constExpr.expression, ExpressionContext.constConstraint)»)
+			.map(«getIteratorVariableName(constExpr)» -> 1.0 * «parseExpression(constExpr.expression, ExpressionContext.constConstraint)»)
 			.reduce(0.0, (sum, value) -> sum + value)'''
 			} else if(constExpr.context instanceof Type) {
 				return '''context.«parseFeatureExpression(constExpr.feature)».stream()
 			«getFilterExpr(constExpr.filter, ExpressionContext.constConstraint)»
-			.map(«getIteratorVariableName(constExpr)» -> «parseExpression(constExpr.expression, ExpressionContext.constConstraint)»)
+			.map(«getIteratorVariableName(constExpr)» -> 1.0 * «parseExpression(constExpr.expression, ExpressionContext.constConstraint)»)
 			.reduce(0.0, (sum, value) -> sum + value)'''
 			} else {
 				throw new UnsupportedOperationException("Unknown context type.");
@@ -590,13 +590,13 @@ abstract class ObjectiveTemplate <OBJECTIVE extends Objective> extends Generator
 			return '''indexer.getObjectsOfType("«varExpr.type.type.name»").parallelStream()
 			.map(type -> («varExpr.type.type.name») type)
 			«getFilterExpr(varExpr.filter, ExpressionContext.varConstraint)»
-			.map(«getIteratorVariableName(varExpr)» -> «parseExpression(varExpr.expression, ExpressionContext.varConstraint)»)
+			.map(«getIteratorVariableName(varExpr)» -> 1.0 * «parseExpression(varExpr.expression, ExpressionContext.varConstraint)»)
 			.reduce(0.0, (sum, value) -> sum + value)'''
 		} else if(varExpr instanceof PatternSumExpression) {
 			imports.add(data.apiData.matchesPkg+"."+data.pattern2matchClassName.get(varExpr.pattern))
 			return '''engine.getEMoflonAPI().«varExpr.pattern.name»().findMatches(false).parallelStream()
 			«getFilterExpr(varExpr.filter, ExpressionContext.varConstraint)»
-			.map(«getIteratorVariableName(varExpr)» -> «parseExpression(varExpr.expression, ExpressionContext.varConstraint)»)
+			.map(«getIteratorVariableName(varExpr)» -> 1.0 * «parseExpression(varExpr.expression, ExpressionContext.varConstraint)»)
 			.reduce(0.0, (sum, value) -> sum + value)'''
 		} else if(varExpr instanceof ContextSumExpression) {
 			if(varExpr.context instanceof Mapping) {
@@ -604,12 +604,12 @@ abstract class ObjectiveTemplate <OBJECTIVE extends Objective> extends Generator
 			} else if(varExpr.context instanceof Pattern) {
 				return '''context.get«varExpr.node.name.toFirstUpper»().«parseFeatureExpression(varExpr.feature)».stream()
 			«getFilterExpr(varExpr.filter, ExpressionContext.varConstraint)»
-			.map(«getIteratorVariableName(varExpr)» -> «parseExpression(varExpr.expression, ExpressionContext.varConstraint)»)
+			.map(«getIteratorVariableName(varExpr)» -> 1.0 * «parseExpression(varExpr.expression, ExpressionContext.varConstraint)»)
 			.reduce(0.0, (sum, value) -> sum + value)'''
 			} else if(varExpr.context instanceof Type) {
 				return '''context.«parseFeatureExpression(varExpr.feature)».stream()
 			«getFilterExpr(varExpr.filter, ExpressionContext.varConstraint)»
-			.map(«getIteratorVariableName(varExpr)» -> «parseExpression(varExpr.expression, ExpressionContext.varConstraint)»)
+			.map(«getIteratorVariableName(varExpr)» -> 1.0 * «parseExpression(varExpr.expression, ExpressionContext.varConstraint)»)
 			.reduce(0.0, (sum, value) -> sum + value)'''
 			} else {
 				throw new UnsupportedOperationException("Unknown context type.");


### PR DESCRIPTION
This fixes multiple bugs regarding the usage of `reduce(...` in the generated code:
- for `int` values from the model, the code was non-compilable (see #114 and #186)
- the semantics were also broken in some cases (e.g., `0.5 / 1` would have evaluated to `0`)

Closes #114.
Closes #186.