### PR TITLE
GIPSL: adds a solver config to dynamically update the solver's time limit depending on the previous run time

### DIFF
--- a/org.emoflon.gips.build/src/org/emoflon/gips/build/transformation/GipsToIntermediate.java
+++ b/org.emoflon.gips.build/src/org/emoflon/gips/build/transformation/GipsToIntermediate.java
@@ -199,7 +199,8 @@ public class GipsToIntermediate {
 
 		config.setEnableTimeLimit(eConfig.isEnableLimit());
 		if (eConfig.isEnableLimit()) {
-			config.setIlpTimeLimit(eConfig.getTimeLimit());
+			config.setTimeLimit(eConfig.getTimeLimit());
+			config.setTimeLimitIncludeInitTime(eConfig.isIncludeInitTime());
 		}
 
 		config.setEnableCustomTolerance(eConfig.isEnableTolerance());

--- a/org.emoflon.gips.core/src/org/emoflon/gips/core/GipsEngine.java
+++ b/org.emoflon.gips.core/src/org/emoflon/gips/core/GipsEngine.java
@@ -25,6 +25,18 @@ public abstract class GipsEngine {
 	protected GipsObjective objective;
 	protected Solver solver;
 
+	/**
+	 * Time tick of the initialization point in time, i.e., the point in time when
+	 * the `api.init(...)` was called.
+	 */
+	protected long tickInit = -1;
+
+	/**
+	 * Time tick of the end of the initialization phase in time, i.e., the time
+	 * point right before the (M)ILP solver starts solving the problem.
+	 */
+	protected long tockInit = -1;
+
 	public abstract void update();
 
 	public abstract void saveResult() throws IOException;
@@ -118,6 +130,7 @@ public abstract class GipsEngine {
 				solver.reset();
 				return output;
 			}
+			this.tockInit();
 			SolverOutput output = solver.solve();
 			if (output.status() != SolverStatus.INFEASIBLE && output.solutionCount() > 0)
 				solver.updateValuesFromSolution();
@@ -134,6 +147,7 @@ public abstract class GipsEngine {
 			solver.reset();
 			return output;
 		}
+		this.tockInit();
 		SolverOutput output = solver.solve();
 		if (output.status() != SolverStatus.INFEASIBLE && output.solutionCount() > 0)
 			solver.updateValuesFromSolution();
@@ -233,4 +247,28 @@ public abstract class GipsEngine {
 	public void setSolver(final Solver solver) {
 		this.solver = solver;
 	}
+
+	/**
+	 * Registers the time point when the initialization tick was executed.
+	 */
+	protected void tickInit() {
+		this.tickInit = System.nanoTime();
+	}
+
+	/**
+	 * Registers the time point when the initialization tock was executed.
+	 */
+	protected void tockInit() {
+		this.tockInit = System.nanoTime();
+	}
+
+	/**
+	 * Returns the complete initialization time in seconds.
+	 * 
+	 * @return Complete initialization time in seconds.
+	 */
+	public double getInitTimeInSeconds() {
+		return 1.0 * (tockInit - tickInit) / 1_000_000_000;
+	}
+
 }

--- a/org.emoflon.gips.core/src/org/emoflon/gips/core/api/GipsEngineAPI.java
+++ b/org.emoflon.gips.core/src/org/emoflon/gips/core/api/GipsEngineAPI.java
@@ -59,7 +59,7 @@ public abstract class GipsEngineAPI<EMOFLON_APP extends GraphTransformationApp<E
 	 * @param numberOfThreads Number of ILP solver threads to set.
 	 */
 	public void setIlpSolverThreads(final int numberOfThreads) {
-		this.solverConfig = solverConfig.withThreadCount(numberOfThreads);
+		setSolverConfig(solverConfig.withThreadCount(numberOfThreads));
 	}
 
 	/**
@@ -69,7 +69,7 @@ public abstract class GipsEngineAPI<EMOFLON_APP extends GraphTransformationApp<E
 	 * @param newTimeLimit New time limit to set.
 	 */
 	public void setTimeLimit(final double newTimeLimit) {
-		this.solverConfig = solverConfig.withNewTimeLimit(newTimeLimit);
+		setSolverConfig(solverConfig.withNewTimeLimit(newTimeLimit));
 	}
 
 	public EMOFLON_APP getEMoflonApp() {

--- a/org.emoflon.gips.core/src/org/emoflon/gips/core/api/GipsEngineAPI.java
+++ b/org.emoflon.gips.core/src/org/emoflon/gips/core/api/GipsEngineAPI.java
@@ -40,6 +40,11 @@ public abstract class GipsEngineAPI<EMOFLON_APP extends GraphTransformationApp<E
 	}
 
 	public void setSolverConfig(final SolverConfig solverConfig) {
+		try {
+			this.solver.setSolverConfig(solverConfig);
+		} catch (final Exception e) {
+			throw new InternalError("Solver re-initialization failed: " + e);
+		}
 		this.solverConfig = solverConfig;
 	}
 

--- a/org.emoflon.gips.core/src/org/emoflon/gips/core/api/GipsEngineAPI.java
+++ b/org.emoflon.gips.core/src/org/emoflon/gips/core/api/GipsEngineAPI.java
@@ -57,6 +57,16 @@ public abstract class GipsEngineAPI<EMOFLON_APP extends GraphTransformationApp<E
 		this.solverConfig = solverConfig.withThreadCount(numberOfThreads);
 	}
 
+	/**
+	 * Overwrite the previously configured time limit with the given parameter's
+	 * value.
+	 * 
+	 * @param newTimeLimit New time limit to set.
+	 */
+	public void setTimeLimit(final double newTimeLimit) {
+		this.solverConfig = solverConfig.withNewTimeLimit(newTimeLimit);
+	}
+
 	public EMOFLON_APP getEMoflonApp() {
 		return eMoflonApp;
 	}
@@ -177,7 +187,8 @@ public abstract class GipsEngineAPI<EMOFLON_APP extends GraphTransformationApp<E
 	}
 
 	protected void setSolverConfig(final org.emoflon.gips.intermediate.GipsIntermediate.SolverConfig config) {
-		solverConfig = new SolverConfig(config.isEnableTimeLimit(), config.getIlpTimeLimit(), //
+		solverConfig = new SolverConfig(config.isEnableTimeLimit(), config.getTimeLimit(),
+				config.isTimeLimitIncludeInitTime(), //
 				config.isEnableRndSeed(), config.getIlpRndSeed(), //
 				config.isEnablePresolve(), //
 				config.isEnableDebugOutput(), //
@@ -195,6 +206,7 @@ public abstract class GipsEngineAPI<EMOFLON_APP extends GraphTransformationApp<E
 	 * @param modelUri     Model URI to load.
 	 */
 	protected void initInternal(final URI gipsModelURI, final URI modelUri) {
+		tickInit();
 		loadIntermediateModel(gipsModelURI);
 		eMoflonApp.registerMetaModels();
 		eMoflonApp.loadModel(modelUri);
@@ -219,6 +231,7 @@ public abstract class GipsEngineAPI<EMOFLON_APP extends GraphTransformationApp<E
 	 * @param ibexPatternPath IBeX pattern path to load.
 	 */
 	protected void initInternal(final URI gipsModelURI, final URI modelUri, final URI ibexPatternPath) {
+		tickInit();
 		loadIntermediateModel(gipsModelURI);
 		eMoflonApp.registerMetaModels();
 		eMoflonApp.loadModel(modelUri);
@@ -242,6 +255,7 @@ public abstract class GipsEngineAPI<EMOFLON_APP extends GraphTransformationApp<E
 	 *                     instance.
 	 */
 	protected void initInternal(final URI gipsModelURI, final ResourceSet model) {
+		tickInit();
 		loadIntermediateModel(gipsModelURI);
 		eMoflonApp.registerMetaModels();
 		eMoflonApp.setModel(model);
@@ -267,6 +281,7 @@ public abstract class GipsEngineAPI<EMOFLON_APP extends GraphTransformationApp<E
 	 * @param ibexPatternPath IBeX pattern path to load.
 	 */
 	protected void initInternal(final URI gipsModelURI, final ResourceSet model, final URI ibexPatternPath) {
+		tickInit();
 		loadIntermediateModel(gipsModelURI);
 		eMoflonApp.registerMetaModels();
 		eMoflonApp.setModel(model);

--- a/org.emoflon.gips.core/src/org/emoflon/gips/core/milp/CplexSolver.java
+++ b/org.emoflon.gips.core/src/org/emoflon/gips/core/milp/CplexSolver.java
@@ -64,18 +64,12 @@ public class CplexSolver extends Solver {
 	 */
 	private String lpPath = null;
 
-	/**
-	 * ILP solver configuration.
-	 */
-	final private SolverConfig config;
-
 	public CplexSolver(final GipsEngine engine, final SolverConfig config) {
-		super(engine);
-		this.config = config;
+		super(engine, config);
 		init();
 	}
 
-	private void init() {
+	protected void init() {
 		try {
 			cplex = new IloCplex();
 			if (config.timeLimitEnabled()) {

--- a/org.emoflon.gips.core/src/org/emoflon/gips/core/milp/CplexSolver.java
+++ b/org.emoflon.gips.core/src/org/emoflon/gips/core/milp/CplexSolver.java
@@ -140,6 +140,29 @@ public class CplexSolver extends Solver {
 			}
 		}
 
+		// If necessary, overwrite time limit with:
+		// new_time_limit = old_time_limit - init_time_consumed
+		if (this.config.timeLimitIncludeInitTime() && this.engine.getInitTimeInSeconds() != 0) {
+			// If the new_time_limit is not >0, the whole solver must not be started at all
+			final double oldTimeLimit = this.config.timeLimit();
+			final double newTimeLimit = oldTimeLimit - this.engine.getInitTimeInSeconds();
+			if (newTimeLimit <= 0) {
+				return new SolverOutput(SolverStatus.TIME_OUT, 0, null, 0, null);
+			}
+			this.config = this.config.withNewTimeLimit(newTimeLimit);
+			try {
+				if (config.timeLimitEnabled()) {
+					if (this.config.enableOutput()) {
+						System.out.println(
+								"=> Debug output: Overwrite specified CPLEX time limit with: " + config.timeLimit());
+					}
+					cplex.setParam(IloCplex.Param.TimeLimit, config.timeLimit());
+				}
+			} catch (final Exception e) {
+				return new SolverOutput(SolverStatus.TIME_OUT, 0, null, 0, null);
+			}
+		}
+
 		try {
 			// Solving
 			final boolean solve = cplex.solve();

--- a/org.emoflon.gips.core/src/org/emoflon/gips/core/milp/GlpkSolver.java
+++ b/org.emoflon.gips.core/src/org/emoflon/gips/core/milp/GlpkSolver.java
@@ -80,20 +80,14 @@ public class GlpkSolver extends Solver {
 	 */
 	private String lpPath = null;
 
-	/**
-	 * ILP solver configuration.
-	 */
-	final private SolverConfig config;
-
 	public GlpkSolver(final GipsEngine engine, final SolverConfig config) {
-		super(engine);
+		super(engine, config);
 		constraints = new HashMap<>();
 		ilpVars = new HashMap<>();
-		this.config = config;
 		init();
 	}
 
-	private void init() {
+	protected void init() {
 		constraints.clear();
 		ilpVars.clear();
 

--- a/org.emoflon.gips.core/src/org/emoflon/gips/core/milp/GurobiSolver.java
+++ b/org.emoflon.gips.core/src/org/emoflon/gips/core/milp/GurobiSolver.java
@@ -130,7 +130,6 @@ public class GurobiSolver extends Solver {
 		} else {
 			model.set(IntParam.Threads, SystemUtil.getSystemThreads());
 		}
-
 		// Reset local lookup data structure for the Gurobi variables in case this is
 		// not the first initialization.
 		grbVars.clear();
@@ -165,7 +164,7 @@ public class GurobiSolver extends Solver {
 						System.out.println(
 								"=> Debug output: Overwrite specified Gurobi time limit with: " + config.timeLimit());
 					}
-					env.set(DoubleParam.TimeLimit, config.timeLimit());
+					model.set(DoubleParam.TimeLimit, config.timeLimit());
 				}
 			} catch (final Exception e) {
 				return new SolverOutput(SolverStatus.TIME_OUT, 0, null, 0, null);

--- a/org.emoflon.gips.core/src/org/emoflon/gips/core/milp/Solver.java
+++ b/org.emoflon.gips.core/src/org/emoflon/gips/core/milp/Solver.java
@@ -14,9 +14,37 @@ import org.emoflon.gips.core.gt.GipsRuleConstraint;
 public abstract class Solver {
 	final protected GipsEngine engine;
 
-	public Solver(final GipsEngine engine) {
+	/**
+	 * ILP solver configuration.
+	 */
+	protected SolverConfig config;
+
+	public Solver(final GipsEngine engine, final SolverConfig config) {
 		this.engine = engine;
+		this.config = config;
 	}
+
+	/**
+	 * Returns the solver configuration.
+	 * 
+	 * @return Solver configuration.
+	 */
+	public SolverConfig getSolverConfig() {
+		return this.config;
+	}
+
+	/**
+	 * Sets a new solver configuration and re-initializes the (M)ILP solver.
+	 * 
+	 * @param config New solver configuration to set.
+	 * @throws Exception Throws an exception if the re-initialization fails.
+	 */
+	public void setSolverConfig(final SolverConfig config) throws Exception {
+		this.config = config;
+		init();
+	}
+
+	protected abstract void init() throws Exception;
 
 	public void buildILPProblem() {
 		engine.getMappers().values().stream().flatMap(mapper -> mapper.getMappings().values().stream())

--- a/org.emoflon.gips.core/src/org/emoflon/gips/core/milp/SolverConfig.java
+++ b/org.emoflon.gips.core/src/org/emoflon/gips/core/milp/SolverConfig.java
@@ -1,14 +1,14 @@
 package org.emoflon.gips.core.milp;
 
-public record SolverConfig(boolean timeLimitEnabled, double timeLimit, boolean rndSeedEnabled, int randomSeed,
-		boolean enablePresolve, boolean enableOutput, boolean enableTolerance, double tolerance, boolean lpOutput,
-		String lpPath, boolean threadCount, int threads) {
+public record SolverConfig(boolean timeLimitEnabled, double timeLimit, boolean timeLimitIncludeInitTime,
+		boolean rndSeedEnabled, int randomSeed, boolean enablePresolve, boolean enableOutput, boolean enableTolerance,
+		double tolerance, boolean lpOutput, String lpPath, boolean threadCount, int threads) {
 
 	/**
-	 * Returns a new ILPSolverConfig record with the given number of threads.
+	 * Returns a new SolverConfig record with the given number of threads.
 	 * 
-	 * @param newThreads Number of threads to be used by the ILP solver.
-	 * @return New ILPSolverConfig record with the given number of threads.
+	 * @param newThreads Number of threads to be used by the (M)ILP solver.
+	 * @return New SolverConfig record with the given number of threads.
 	 */
 	public SolverConfig withThreadCount(final int newThreads) {
 		if (newThreads <= 0) {
@@ -16,13 +16,34 @@ public record SolverConfig(boolean timeLimitEnabled, double timeLimit, boolean r
 		}
 
 		return new SolverConfig( //
-				timeLimitEnabled, timeLimit, //
+				timeLimitEnabled, timeLimit, timeLimitIncludeInitTime, //
 				rndSeedEnabled, randomSeed, //
 				enablePresolve, //
 				enableOutput, //
 				enableTolerance, tolerance, //
 				lpOutput, lpPath, //
 				true, newThreads);
+	}
+
+	/**
+	 * Returns a new SolverConfig record with a new time limit value.
+	 * 
+	 * @param newTimeLimit New time limit value.
+	 * @return New SolverConfig record with the given new time limit.
+	 */
+	public SolverConfig withNewTimeLimit(final double newTimeLimit) {
+		if (newTimeLimit <= 0) {
+			throw new IllegalArgumentException("Given new time limit is smaller or equal to 0.");
+		}
+
+		return new SolverConfig( //
+				timeLimitEnabled, newTimeLimit, timeLimitIncludeInitTime, //
+				rndSeedEnabled, randomSeed, //
+				enablePresolve, //
+				enableOutput, //
+				enableTolerance, tolerance, //
+				lpOutput, lpPath, //
+				threadCount, threads);
 	}
 
 }

--- a/org.emoflon.gips.gipsl/model/generated/Gipsl.ecore
+++ b/org.emoflon.gips.gipsl/model/generated/Gipsl.ecore
@@ -34,6 +34,7 @@
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="mainLoc" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="enableLimit" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="timeLimit" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EDouble"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="includeInitTime" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="enableSeed" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="rndSeed" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EInt"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="enablePresolve" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>

--- a/org.emoflon.gips.gipsl/model/generated/Gipsl.genmodel
+++ b/org.emoflon.gips.gipsl/model/generated/Gipsl.genmodel
@@ -100,6 +100,7 @@
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Gipsl.ecore#//GipsConfig/mainLoc"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Gipsl.ecore#//GipsConfig/enableLimit"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Gipsl.ecore#//GipsConfig/timeLimit"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Gipsl.ecore#//GipsConfig/includeInitTime"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Gipsl.ecore#//GipsConfig/enableSeed"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Gipsl.ecore#//GipsConfig/rndSeed"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Gipsl.ecore#//GipsConfig/enablePresolve"/>

--- a/org.emoflon.gips.gipsl/src/org/emoflon/gips/gipsl/Gipsl.xtext
+++ b/org.emoflon.gips.gipsl/src/org/emoflon/gips/gipsl/Gipsl.xtext
@@ -32,7 +32,7 @@ GipsConfig : {GipsConfig}
 	'config' '{'
 	'solver' ':=' solver=SolverType ('[' ('home' ':=' home=GipsStringLiteral ',' 'license' ':=' license=GipsStringLiteral)? ']')? ';'
 	('launchConfig' ':=' enableLaunchConfig = GipsBoolean '[' 'main' ':=' mainLoc=GipsStringLiteral ']' ';')?
-	('timeLimit' ':=' enableLimit = GipsBoolean '[' 'value' ':=' timeLimit=GipsDouble ']' ';')?
+	('timeLimit' ':=' enableLimit = GipsBoolean '[' 'value' ':=' timeLimit=GipsDouble (',' 'includeInitTime' ':=' includeInitTime=GipsBoolean)? ']' ';')?
 	('randomSeed' ':=' enableSeed = GipsBoolean '[' 'value' ':=' rndSeed=GipsInteger ']' ';')?
 	('presolve' ':=' enablePresolve = GipsBoolean ';')?
 	('debugOutput' ':=' enableDebugOutput = GipsBoolean ';')?

--- a/org.emoflon.gips.intermediate/model/GipsIntermediate.ecore
+++ b/org.emoflon.gips.intermediate/model/GipsIntermediate.ecore
@@ -37,7 +37,9 @@
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="buildLaunchConfig" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="mainFile" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="enableTimeLimit" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="ilpTimeLimit" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EDouble"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="timeLimit" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EDouble"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="timeLimitIncludeInitTime"
+        ordered="false" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="enableRndSeed" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="ilpRndSeed" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EInt"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="presolve" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>

--- a/org.emoflon.gips.intermediate/model/GipsIntermediate.genmodel
+++ b/org.emoflon.gips.intermediate/model/GipsIntermediate.genmodel
@@ -11,10 +11,10 @@
   <testsDirectory xsi:nil="true"/>
   <genPackages prefix="GipsIntermediate" basePackage="org.emoflon.gips.intermediate"
       disposableProviderFactory="true" ecorePackage="GipsIntermediate.ecore#/">
-    <genEnums typeSafeEnumCompatible="false" ecoreEnum="GipsIntermediate.ecore#//ILPSolverType">
-      <genEnumLiterals ecoreEnumLiteral="GipsIntermediate.ecore#//ILPSolverType/GUROBI"/>
-      <genEnumLiterals ecoreEnumLiteral="GipsIntermediate.ecore#//ILPSolverType/GLPK"/>
-      <genEnumLiterals ecoreEnumLiteral="GipsIntermediate.ecore#//ILPSolverType/CPLEX"/>
+    <genEnums typeSafeEnumCompatible="false" ecoreEnum="GipsIntermediate.ecore#//SolverType">
+      <genEnumLiterals ecoreEnumLiteral="GipsIntermediate.ecore#//SolverType/GUROBI"/>
+      <genEnumLiterals ecoreEnumLiteral="GipsIntermediate.ecore#//SolverType/GLPK"/>
+      <genEnumLiterals ecoreEnumLiteral="GipsIntermediate.ecore#//SolverType/CPLEX"/>
     </genEnums>
     <genEnums typeSafeEnumCompatible="false" ecoreEnum="GipsIntermediate.ecore#//VariableType">
       <genEnumLiterals ecoreEnumLiteral="GipsIntermediate.ecore#//VariableType/BINARY"/>
@@ -58,10 +58,10 @@
       <genEnumLiterals ecoreEnumLiteral="GipsIntermediate.ecore#//ArithmeticUnaryOperator/COSINE"/>
       <genEnumLiterals ecoreEnumLiteral="GipsIntermediate.ecore#//ArithmeticUnaryOperator/SQRT"/>
     </genEnums>
-    <genEnums typeSafeEnumCompatible="false" ecoreEnum="GipsIntermediate.ecore#//Constant">
-      <genEnumLiterals ecoreEnumLiteral="GipsIntermediate.ecore#//Constant/PI"/>
-      <genEnumLiterals ecoreEnumLiteral="GipsIntermediate.ecore#//Constant/E"/>
-      <genEnumLiterals ecoreEnumLiteral="GipsIntermediate.ecore#//Constant/NULL"/>
+    <genEnums typeSafeEnumCompatible="false" ecoreEnum="GipsIntermediate.ecore#//ConstantValue">
+      <genEnumLiterals ecoreEnumLiteral="GipsIntermediate.ecore#//ConstantValue/PI"/>
+      <genEnumLiterals ecoreEnumLiteral="GipsIntermediate.ecore#//ConstantValue/E"/>
+      <genEnumLiterals ecoreEnumLiteral="GipsIntermediate.ecore#//ConstantValue/NULL"/>
     </genEnums>
     <genEnums typeSafeEnumCompatible="false" ecoreEnum="GipsIntermediate.ecore#//ConcatenationOperator">
       <genEnumLiterals ecoreEnumLiteral="GipsIntermediate.ecore#//ConcatenationOperator/PREPEND"/>
@@ -86,31 +86,36 @@
     <genClasses ecoreClass="GipsIntermediate.ecore#//GipsIntermediateModel">
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference GipsIntermediate.ecore#//GipsIntermediateModel/ibexModel"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference GipsIntermediate.ecore#//GipsIntermediateModel/config"/>
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference GipsIntermediate.ecore#//GipsIntermediateModel/constants"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference GipsIntermediate.ecore#//GipsIntermediateModel/variables"/>
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference GipsIntermediate.ecore#//GipsIntermediateModel/mappings"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference GipsIntermediate.ecore#//GipsIntermediateModel/constraints"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference GipsIntermediate.ecore#//GipsIntermediateModel/functions"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference GipsIntermediate.ecore#//GipsIntermediateModel/objective"/>
+      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference GipsIntermediate.ecore#//GipsIntermediateModel/requiredTypes"/>
+      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference GipsIntermediate.ecore#//GipsIntermediateModel/requiredPatterns"/>
+      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference GipsIntermediate.ecore#//GipsIntermediateModel/requiredRules"/>
     </genClasses>
-    <genClasses ecoreClass="GipsIntermediate.ecore#//ILPConfig">
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GipsIntermediate.ecore#//ILPConfig/solver"/>
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GipsIntermediate.ecore#//ILPConfig/solverHomeDir"/>
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GipsIntermediate.ecore#//ILPConfig/solverLicenseFile"/>
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GipsIntermediate.ecore#//ILPConfig/buildLaunchConfig"/>
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GipsIntermediate.ecore#//ILPConfig/mainFile"/>
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GipsIntermediate.ecore#//ILPConfig/enableTimeLimit"/>
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GipsIntermediate.ecore#//ILPConfig/ilpTimeLimit"/>
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GipsIntermediate.ecore#//ILPConfig/enableRndSeed"/>
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GipsIntermediate.ecore#//ILPConfig/ilpRndSeed"/>
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GipsIntermediate.ecore#//ILPConfig/presolve"/>
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GipsIntermediate.ecore#//ILPConfig/enablePresolve"/>
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GipsIntermediate.ecore#//ILPConfig/enableDebugOutput"/>
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GipsIntermediate.ecore#//ILPConfig/enableCustomTolerance"/>
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GipsIntermediate.ecore#//ILPConfig/tolerance"/>
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GipsIntermediate.ecore#//ILPConfig/enableLpOutput"/>
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GipsIntermediate.ecore#//ILPConfig/lpPath"/>
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GipsIntermediate.ecore#//ILPConfig/threadCountEnabled"/>
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GipsIntermediate.ecore#//ILPConfig/threadCount"/>
+    <genClasses ecoreClass="GipsIntermediate.ecore#//SolverConfig">
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GipsIntermediate.ecore#//SolverConfig/solver"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GipsIntermediate.ecore#//SolverConfig/solverHomeDir"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GipsIntermediate.ecore#//SolverConfig/solverLicenseFile"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GipsIntermediate.ecore#//SolverConfig/buildLaunchConfig"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GipsIntermediate.ecore#//SolverConfig/mainFile"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GipsIntermediate.ecore#//SolverConfig/enableTimeLimit"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GipsIntermediate.ecore#//SolverConfig/timeLimit"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GipsIntermediate.ecore#//SolverConfig/timeLimitSubstractPmTime"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GipsIntermediate.ecore#//SolverConfig/enableRndSeed"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GipsIntermediate.ecore#//SolverConfig/ilpRndSeed"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GipsIntermediate.ecore#//SolverConfig/presolve"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GipsIntermediate.ecore#//SolverConfig/enablePresolve"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GipsIntermediate.ecore#//SolverConfig/enableDebugOutput"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GipsIntermediate.ecore#//SolverConfig/enableCustomTolerance"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GipsIntermediate.ecore#//SolverConfig/tolerance"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GipsIntermediate.ecore#//SolverConfig/enableLpOutput"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GipsIntermediate.ecore#//SolverConfig/lpPath"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GipsIntermediate.ecore#//SolverConfig/threadCountEnabled"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GipsIntermediate.ecore#//SolverConfig/threadCount"/>
     </genClasses>
     <genClasses ecoreClass="GipsIntermediate.ecore#//Variable">
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GipsIntermediate.ecore#//Variable/type"/>
@@ -133,12 +138,17 @@
     <genClasses ecoreClass="GipsIntermediate.ecore#//PatternMapping">
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference GipsIntermediate.ecore#//PatternMapping/pattern"/>
     </genClasses>
+    <genClasses ecoreClass="GipsIntermediate.ecore#//Constant">
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference GipsIntermediate.ecore#//Constant/expression"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GipsIntermediate.ecore#//Constant/global"/>
+    </genClasses>
     <genClasses image="false" ecoreClass="GipsIntermediate.ecore#//Context"/>
     <genClasses image="false" ecoreClass="GipsIntermediate.ecore#//Constraint">
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GipsIntermediate.ecore#//Constraint/global"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GipsIntermediate.ecore#//Constraint/depending"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GipsIntermediate.ecore#//Constraint/constant"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GipsIntermediate.ecore#//Constraint/negated"/>
+      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference GipsIntermediate.ecore#//Constraint/constants"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference GipsIntermediate.ecore#//Constraint/expression"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference GipsIntermediate.ecore#//Constraint/dependencies"/>
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference GipsIntermediate.ecore#//Constraint/referencedBy"/>
@@ -147,15 +157,21 @@
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference GipsIntermediate.ecore#//Constraint/helperConstraints"/>
     </genClasses>
     <genClasses ecoreClass="GipsIntermediate.ecore#//LinearFunction">
+      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference GipsIntermediate.ecore#//LinearFunction/constants"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference GipsIntermediate.ecore#//LinearFunction/expression"/>
     </genClasses>
     <genClasses ecoreClass="GipsIntermediate.ecore#//Objective">
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GipsIntermediate.ecore#//Objective/goal"/>
+      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference GipsIntermediate.ecore#//Objective/constants"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference GipsIntermediate.ecore#//Objective/expression"/>
     </genClasses>
     <genClasses ecoreClass="GipsIntermediate.ecore#//PatternConstraint">
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference GipsIntermediate.ecore#//PatternConstraint/pattern"/>
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference GipsIntermediate.ecore#//PatternConstraint/contextPattern"/>
+    </genClasses>
+    <genClasses ecoreClass="GipsIntermediate.ecore#//RuleConstraint">
+      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference GipsIntermediate.ecore#//RuleConstraint/rule"/>
+      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference GipsIntermediate.ecore#//RuleConstraint/contextPattern"/>
     </genClasses>
     <genClasses ecoreClass="GipsIntermediate.ecore#//TypeConstraint">
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference GipsIntermediate.ecore#//TypeConstraint/type"/>
@@ -166,6 +182,10 @@
     <genClasses ecoreClass="GipsIntermediate.ecore#//PatternFunction">
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference GipsIntermediate.ecore#//PatternFunction/pattern"/>
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference GipsIntermediate.ecore#//PatternFunction/contextPattern"/>
+    </genClasses>
+    <genClasses ecoreClass="GipsIntermediate.ecore#//RuleFunction">
+      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference GipsIntermediate.ecore#//RuleFunction/rule"/>
+      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference GipsIntermediate.ecore#//RuleFunction/contextPattern"/>
     </genClasses>
     <genClasses ecoreClass="GipsIntermediate.ecore#//TypeFunction">
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference GipsIntermediate.ecore#//TypeFunction/type"/>
@@ -190,6 +210,7 @@
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GipsIntermediate.ecore#//RelationalExpression/operator"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference GipsIntermediate.ecore#//RelationalExpression/lhs"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference GipsIntermediate.ecore#//RelationalExpression/rhs"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GipsIntermediate.ecore#//RelationalExpression/requiresComparables"/>
     </genClasses>
     <genClasses ecoreClass="GipsIntermediate.ecore#//ArithmeticExpression"/>
     <genClasses ecoreClass="GipsIntermediate.ecore#//ArithmeticBinaryExpression">
@@ -211,6 +232,13 @@
     <genClasses ecoreClass="GipsIntermediate.ecore#//ConstantLiteral">
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GipsIntermediate.ecore#//ConstantLiteral/constant"/>
     </genClasses>
+    <genClasses ecoreClass="GipsIntermediate.ecore#//ConstantReference">
+      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference GipsIntermediate.ecore#//ConstantReference/constant"/>
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference GipsIntermediate.ecore#//ConstantReference/setExpression"/>
+    </genClasses>
+    <genClasses ecoreClass="GipsIntermediate.ecore#//LinearFunctionReference">
+      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference GipsIntermediate.ecore#//LinearFunctionReference/function"/>
+    </genClasses>
     <genClasses image="false" ecoreClass="GipsIntermediate.ecore#//ValueExpression">
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference GipsIntermediate.ecore#//ValueExpression/setExpression"/>
     </genClasses>
@@ -229,10 +257,11 @@
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference GipsIntermediate.ecore#//RuleReference/rule"/>
     </genClasses>
     <genClasses image="false" ecoreClass="GipsIntermediate.ecore#//ContextReference">
-      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference GipsIntermediate.ecore#//ContextReference/context"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GipsIntermediate.ecore#//ContextReference/local"/>
     </genClasses>
     <genClasses ecoreClass="GipsIntermediate.ecore#//NodeReference">
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference GipsIntermediate.ecore#//NodeReference/node"/>
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference GipsIntermediate.ecore#//NodeReference/attribute"/>
     </genClasses>
     <genClasses ecoreClass="GipsIntermediate.ecore#//AttributeReference">
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference GipsIntermediate.ecore#//AttributeReference/attribute"/>


### PR DESCRIPTION
This PR introduces a new (optional) config flag for the solver section in GIPSL:

```
config {
        [...]
	timeLimit := true [value := 120.0, includeInitTime := true];
        [...]
}
```

If set to `true`, the time from the call to `initInternal([...])` of the API until the start of the (M)ILP solving process will be measured and subtracted from the configured time limit.

Example:
- As in the snippet above, the global time limit shall be configured to `120.0` = 120s.
- If `includeInitTime := false`, the (M)ILP solver gets the time limit of 120s nevertheless how long the pattern matching, as well as the building of the (M)ILP problem, took.
- If `includeInitTime := true`, the (M)ILP solver gets the time limit of 120 - t_init. For example, if the pattern matching took 2s and the building of the (M)ILP problem took 1s, the solver gets the time out 120 - 2 - 1 = 117s.

As a result, this configuration option allows for setting a more "global" time limit on how long the GIPS approach takes to solve a problem.

If t_limit - t_init < 0 (i.e., the initialization phase and the pattern matching took longer than the configured time limit), the API will not terminate directly after the time out. Still, it will not start the (M)ILP solver afterward but return a time-out solution object.