### PR TITLE
Fix used editor ID to open editor from context menu

### DIFF
--- a/org.emoflon.gips.eclipse.cplexlp.ui/src/org/emoflon/gips/eclipse/ui/editor/CplexLpEditor.java
+++ b/org.emoflon.gips.eclipse.cplexlp.ui/src/org/emoflon/gips/eclipse/ui/editor/CplexLpEditor.java
@@ -1,8 +1,11 @@
 package org.emoflon.gips.eclipse.ui.editor;
 
 import org.eclipse.xtext.ui.editor.XtextEditor;
+import org.emoflon.gips.eclipse.CplexLpLanguage;
 
 public class CplexLpEditor extends XtextEditor {
+
+	public static final String EDITOR_ID = CplexLpLanguage.LANGUAGE_NAME;
 
 //    @Inject
 //    private XbaseEditorInputRedirector editorInputRedirector;

--- a/org.emoflon.gips.eclipse/META-INF/MANIFEST.MF
+++ b/org.emoflon.gips.eclipse/META-INF/MANIFEST.MF
@@ -36,6 +36,7 @@ Require-Bundle: org.eclipse.ui,
  org.emoflon.gips.gipsl,
  org.eclipse.jface,
  org.emoflon.gips.eclipse.cplexlp;bundle-version="[1.0.0,2.0.0)",
+ org.emoflon.gips.eclipse.cplexlp.ui;bundle-version="[1.0.0,2.0.0)",
  org.emoflon.gips.eclipse.trace;bundle-version="[1.0.0,2.0.0)";visibility:=reexport
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: org.emoflon.gips.eclipse

--- a/org.emoflon.gips.eclipse/src/org/emoflon/gips/eclipse/menu/ContributionOpenLpFile.java
+++ b/org.emoflon.gips.eclipse/src/org/emoflon/gips/eclipse/menu/ContributionOpenLpFile.java
@@ -14,6 +14,7 @@ import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.actions.CompoundContributionItem;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.xtext.ui.editor.XtextEditor;
+import org.emoflon.gips.eclipse.ui.editor.CplexLpEditor;
 import org.emoflon.gips.eclipse.utility.HelperErrorDialog;
 import org.emoflon.gips.eclipse.utility.HelperGipsl;
 
@@ -47,8 +48,7 @@ public class ContributionOpenLpFile extends CompoundContributionItem {
 						final var targetFile = ResourcesPlugin.getWorkspace().getRoot().getFile(targetPath);
 
 						try {
-							IDE.openEditor(part.getSite().getPage(), targetFile, "org.emoflon.gips.debugger.CplexLp",
-									true);
+							IDE.openEditor(part.getSite().getPage(), targetFile, CplexLpEditor.EDITOR_ID, true);
 						} catch (final PartInitException ex) {
 							ex.printStackTrace();
 							var error = HelperErrorDialog.createMultiStatus(ex.getLocalizedMessage(), ex);


### PR DESCRIPTION
The right-click context action on GIPSL files (GIPS->Open LP-File: ...) broke after the name change of the trace plugin. This is because it still uses the old Cplex-Lp-Editor ID. This commit replaces the old ID with a static field reference that holds the (correct) editor ID.

Reproduction steps:
- Open a GIPSL file in which the lpOutput parameter has been set to point to an existing LP file.
- Right click inside the editor and go to _GIPS_ -> _Open LP-File: ..._ and click on it

Expected result::
- The LP file will open inside the Cplex-Lp-Editor