### PR TITLE
Fix/display trace onoff button

### DIFF
--- a/org.emoflon.gips.eclipse/META-INF/MANIFEST.MF
+++ b/org.emoflon.gips.eclipse/META-INF/MANIFEST.MF
@@ -35,6 +35,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.emf.ecore,
  org.emoflon.gips.gipsl,
  org.eclipse.jface,
+ org.eclipse.core.expressions,
  org.emoflon.gips.eclipse.cplexlp;bundle-version="[1.0.0,2.0.0)",
  org.emoflon.gips.eclipse.cplexlp.ui;bundle-version="[1.0.0,2.0.0)",
  org.emoflon.gips.eclipse.trace;bundle-version="[1.0.0,2.0.0)";visibility:=reexport

--- a/org.emoflon.gips.eclipse/plugin.xml
+++ b/org.emoflon.gips.eclipse/plugin.xml
@@ -34,6 +34,29 @@
                   icon="assets/toggle-visualisation-icon-on.png"
                   id="org.emoflon.gips.eclipse.visualisation.toggle"
                   style="toggle">
+               <visibleWhen
+                     checkEnabled="false">
+                  <or>
+                     <with
+                           variable="activeEditorId">
+                        <or>
+                           <equals
+                                 value="org.emoflon.gips.eclipse.CplexLp">
+                           </equals>
+                           <equals
+                                 value="org.emoflon.gips.gipsl.Gipsl">
+                           </equals>
+                        </or>
+                     </with>
+                     <with
+                           variable="activeEditor">
+                        <instanceof
+                              value="org.eclipse.emf.ecore.presentation.EcoreEditor">
+                        </instanceof>
+                     </with>
+                  </or>
+               </visibleWhen>
+              
             </command>
          </toolbar>
       </menuContribution>

--- a/org.emoflon.gips.eclipse/plugin.xml
+++ b/org.emoflon.gips.eclipse/plugin.xml
@@ -38,22 +38,17 @@
                      checkEnabled="false">
                   <or>
                      <with
-                           variable="activeEditorId">
-                        <or>
-                           <equals
-                                 value="org.emoflon.gips.eclipse.CplexLp">
-                           </equals>
-                           <equals
-                                 value="org.emoflon.gips.gipsl.Gipsl">
-                           </equals>
-                        </or>
-                     </with>
-                     <with
                            variable="activeEditor">
                         <instanceof
                               value="org.eclipse.emf.ecore.presentation.EcoreEditor">
                         </instanceof>
                      </with>
+                     <reference
+                           definitionId="isGIPSLEditorActive">
+                     </reference>
+                     <reference
+                           definitionId="isCplexEditorActive">
+                     </reference>
                   </or>
                </visibleWhen>
               
@@ -169,6 +164,27 @@
             id="org.emoflon.gips.eclipse.page1"
             name="GIPS Tracing">
       </page>
+   </extension>
+   <extension
+         point="org.eclipse.core.expressions.definitions">
+      <definition
+            id="isGIPSLEditorActive">
+         <with
+               variable="activePartId">
+            <equals
+                  value="org.emoflon.gips.gipsl.Gipsl">
+            </equals>
+         </with>
+      </definition>
+      <definition
+            id="isCplexEditorActive">
+         <with
+               variable="activePartId">
+            <equals
+                  value="org.emoflon.gips.eclipse.CplexLp">
+            </equals>
+         </with>
+      </definition>
    </extension>
 
 </plugin>


### PR DESCRIPTION
The toolbar button to enable/disable trace visualisation is only visible when working with supported editors (gipsl, cplex, xmi), otherwise the button is hidden to keep the toolbar clean.
![grafik](https://github.com/user-attachments/assets/9c61a146-3e5e-4315-9bda-dbefd1d4085d)

How to test:
- Open a gipsl, lp or xmi file in an editor. While the editor part has the focus, the button should be visible in the toolbar (see screenshot).
- Focus any other part (editor/view), such as the navigation tree or a java editor. The button should be hidden.
