### PR TITLE
Fix for possible class cast exception

### DIFF
--- a/org.emoflon.gips.eclipse/src/org/emoflon/gips/eclipse/connector/CplexLpEditorTraceConnectionFactory.java
+++ b/org.emoflon.gips.eclipse/src/org/emoflon/gips/eclipse/connector/CplexLpEditorTraceConnectionFactory.java
@@ -45,11 +45,11 @@ public class CplexLpEditorTraceConnectionFactory extends XtextEditorTraceConnect
 			var elementIds = new ArrayList<String>(eObjects.size());
 			for (var eObject : eObjects) {
 				if (eObject instanceof NumberLiteral) {
-					var variable = ((LinearTerm) eObject.eContainer()).getVariable();
-					if (variable == null) {
-						// TODO
+					if (eObject.eContainer() instanceof LinearTerm linearTerm) {
+						if (linearTerm.getVariable() != null)
+							eObject = linearTerm.getVariable();
 					} else {
-						eObject = variable;
+						eObject = eObject.eContainer();
 					}
 				}
 


### PR DESCRIPTION
Selecting the number literal on the right-hand side of a constraint can sometimes cause a class cast exception within the trace visualisation framework. To solve this problem, this PR adds an instanceof-check before casting.

Reproduction steps before:
- Open an lp file
- Enable trace visualisation
- Click (or select) on the number literal on the right-hand side of a constraint
- An error dialog with one or more class-cast related errors may appear