### PR TITLE
Updates the version numbers of the new dependencies in `build.properties`

### DIFF
--- a/org.emoflon.gips.core.dependencies/build.properties
+++ b/org.emoflon.gips.core.dependencies/build.properties
@@ -6,18 +6,18 @@ bin.includes = META-INF/,\
                lib/logicng-2.6.0-javadoc.jar,\
                lib/logicng-parser-j8-2.6.0.jar,\
                lib/logicng-parser-j8-2.6.0-javadoc.jar,\
-               lib/slf4j-api-2.0.16.jar,\
-               lib/slf4j-api-2.0.16-javadoc.jar,\
-               lib/oshi-core-6.6.5.jar,\
-               lib/oshi-core-6.6.5-javadoc.jar,\
-               lib/oshi-core-6.6.5-sources.jar,\
+               lib/slf4j-api-2.0.17.jar,\
+               lib/slf4j-api-2.0.17-javadoc.jar,\
+               lib/oshi-core-6.8.0.jar,\
+               lib/oshi-core-6.8.0-javadoc.jar,\
+               lib/oshi-core-6.8.0-sources.jar,\
                lib/jna-5.15.0.jar,\
                lib/jna-5.15.0-javadoc.jar,\
                lib/jna-5.15.0-sources.jar,\
                lib/jna-platform-5.15.0.jar,\
                lib/jna-platform-5.15.0-javadoc.jar,\
                lib/jna-platform-5.15.0-sources.jar,\
-               lib/slf4j-nop-2.0.16.jar,\
-               lib/slf4j-nop-2.0.16-javadoc.jar,\
+               lib/slf4j-nop-2.0.17.jar,\
+               lib/slf4j-nop-2.0.17-javadoc.jar,\
                lib/gurobi-12.0.1.jar,\
                lib/gurobi-javadoc-12.0.1.jar


### PR DESCRIPTION
This fixes a broken update site build after merging the previously updated dependencies.