### PR TITLE
Process solution values for code mining only if enabled

### DIFF
--- a/org.emoflon.gips.core/src/org/emoflon/gips/core/milp/CplexSolver.java
+++ b/org.emoflon.gips.core/src/org/emoflon/gips/core/milp/CplexSolver.java
@@ -347,7 +347,7 @@ public class CplexSolver extends Solver {
 						try {
 							return Math.round(cplex.getValue(e.getValue()));
 						} catch (IloException e1) {
-							return 0;
+							return null;
 						}
 					})));
 		}

--- a/org.emoflon.gips.core/src/org/emoflon/gips/core/milp/CplexSolver.java
+++ b/org.emoflon.gips.core/src/org/emoflon/gips/core/milp/CplexSolver.java
@@ -341,14 +341,16 @@ public class CplexSolver extends Solver {
 		}
 		// Solver reset will be handled by the GipsEngine afterward
 
-		engine.getEclipseIntegration()
-				.storeSolutionValues(this.vars.entrySet().stream().collect(Collectors.toMap(Entry::getKey, e -> {
-					try {
-						return Math.round(cplex.getValue(e.getValue()));
-					} catch (IloException e1) {
-						return 0;
-					}
-				})));
+		if (engine.getEclipseIntegration().getConfig().isSolutionValuesSynchronizationEnabled()) {
+			engine.getEclipseIntegration()
+					.storeSolutionValues(this.vars.entrySet().stream().collect(Collectors.toMap(Entry::getKey, e -> {
+						try {
+							return Math.round(cplex.getValue(e.getValue()));
+						} catch (IloException e1) {
+							return 0;
+						}
+					})));
+		}
 	}
 
 	@Override

--- a/org.emoflon.gips.core/src/org/emoflon/gips/core/milp/GlpkSolver.java
+++ b/org.emoflon.gips.core/src/org/emoflon/gips/core/milp/GlpkSolver.java
@@ -244,8 +244,10 @@ public class GlpkSolver extends Solver {
 		}
 		// Solver reset will be handled by the GipsEngine afterward
 
-		engine.getEclipseIntegration().storeSolutionValues(this.ilpVars.entrySet().stream().collect(
-				Collectors.toMap(Entry::getKey, e -> Math.round(GLPK.glp_mip_col_val(model, e.getValue().index)))));
+		if (engine.getEclipseIntegration().getConfig().isSolutionValuesSynchronizationEnabled()) {
+			engine.getEclipseIntegration().storeSolutionValues(this.ilpVars.entrySet().stream().collect(
+					Collectors.toMap(Entry::getKey, e -> Math.round(GLPK.glp_mip_col_val(model, e.getValue().index)))));
+		}
 	}
 
 	@Override

--- a/org.emoflon.gips.core/src/org/emoflon/gips/core/milp/GurobiSolver.java
+++ b/org.emoflon.gips.core/src/org/emoflon/gips/core/milp/GurobiSolver.java
@@ -378,14 +378,16 @@ public class GurobiSolver extends Solver {
 		}
 		// Solver reset will be handled by the GipsEngine afterward
 
-		engine.getEclipseIntegration()
-				.storeSolutionValues(this.grbVars.entrySet().stream().collect(Collectors.toMap(Entry::getKey, e -> {
-					try {
-						return Math.round(getVar(e.getKey()).get(DoubleAttr.X));
-					} catch (GRBException e1) {
-						return 0;
-					}
-				})));
+		if (engine.getEclipseIntegration().getConfig().isSolutionValuesSynchronizationEnabled()) {
+			engine.getEclipseIntegration()
+					.storeSolutionValues(this.grbVars.entrySet().stream().collect(Collectors.toMap(Entry::getKey, e -> {
+						try {
+							return Math.round(getVar(e.getKey()).get(DoubleAttr.X));
+						} catch (GRBException e1) {
+							return 0;
+						}
+					})));
+		}
 	}
 
 	@Override

--- a/org.emoflon.gips.core/src/org/emoflon/gips/core/milp/GurobiSolver.java
+++ b/org.emoflon.gips.core/src/org/emoflon/gips/core/milp/GurobiSolver.java
@@ -384,7 +384,7 @@ public class GurobiSolver extends Solver {
 						try {
 							return Math.round(getVar(e.getKey()).get(DoubleAttr.X));
 						} catch (GRBException e1) {
-							return 0;
+							return null;
 						}
 					})));
 		}

--- a/org.emoflon.gips.core/src/org/emoflon/gips/core/trace/EclipseIntegration.java
+++ b/org.emoflon.gips.core/src/org/emoflon/gips/core/trace/EclipseIntegration.java
@@ -148,9 +148,6 @@ public class EclipseIntegration {
 	public void storeSolutionValues(Map<String, Number> values) {
 		storedILPValues.clear();
 
-		if (!config.isSolutionValuesSynchronizationEnabled())
-			return;
-
 		for (var entry : values.entrySet()) {
 			if (entry.getValue() != null) {
 				storedILPValues.put(entry.getKey(), entry.getValue().toString());


### PR DESCRIPTION
As part of code mining, this PR also disables the (unnecessary) processing of solution values for code mining, when the 'isSolutionValuesSynchronizationEnabled' flag is false. Previously they were processed but not sent to the IDE when the flag was false.