### PR TITLE
Disableable GIPSL->Intermediate trace in Eclipse preference page

### DIFF
--- a/org.emoflon.gips.build/src/org/emoflon/gips/build/GipsBuilderUtils.java
+++ b/org.emoflon.gips.build/src/org/emoflon/gips/build/GipsBuilderUtils.java
@@ -320,28 +320,29 @@ public final class GipsBuilderUtils {
 		ITraceContext traceContext = ITraceManager.getInstance().getContext(project.getName());
 
 		try {
-			// adjust file extension from xmi to gipsl
+			// The first segment of a URI is the project name, by removing this segment we
+			// get a project relative path. The intermediateModelURI, although 'stored' as a
+			// platform URI, is not a valid platform URI because the first segment is not
+			// the project name.
 
-			// first segment of an URI is the project name, by removing it we get a
-			// project relative path
+			// adjust file extension from xmi to gipsl
 			URI gipslURI = HelperEclipse.toPlatformURI(gipslModelURI.trimFileExtension().appendFileExtension("gipsl"));
 			IPath gipslPath = IPath.fromOSString(gipslURI.toPlatformString(true)).makeRelative().removeFirstSegments(1);
+			String gipslModelId = gipslPath.toString();
 
 			URI intermediateURI = HelperEclipse.toPlatformURI(intermediateModelURI);
 			IPath intermediatePath = IPath.fromOSString(intermediateURI.toPlatformString(true)).makeRelative();
-
-			String gipslModelId = gipslPath.toString(); // gipslModelURI.trimFileExtension().lastSegment();
-			String intermediateModelId = intermediatePath.toString(); // intermediateModelURI.trimFileExtension().lastSegment();
+			String intermediateModelId = intermediatePath.toString();
 
 			if (gipslModelId.equalsIgnoreCase(intermediateModelId))
 				throw new IllegalArgumentException(
 						"GIPSL and Intermediate model id should not be equal: '" + gipslModelId + "'");
 
-			TraceMap<String, String> gipsl2intermediateMppings = TraceMap.normalize(gipsTracer.getMap(),
+			TraceMap<String, String> gipsl2intermediateMappings = TraceMap.normalize(gipsTracer.getMap(),
 					ResolveEcore2Id.INSTANCE, ResolveEcore2Id.INSTANCE);
 
-			traceContext
-					.updateTraceModel(new TraceModelLink(gipslModelId, intermediateModelId, gipsl2intermediateMppings));
+			traceContext.updateTraceModel(
+					new TraceModelLink(gipslModelId, intermediateModelId, gipsl2intermediateMappings));
 		} catch (Exception e) {
 			e.printStackTrace();
 		}

--- a/org.emoflon.gips.build/src/org/emoflon/gips/build/GipsBuilderUtils.java
+++ b/org.emoflon.gips.build/src/org/emoflon/gips/build/GipsBuilderUtils.java
@@ -310,6 +310,10 @@ public final class GipsBuilderUtils {
 	 */
 	public static void updateTrace(final IProject project, final URI gipslModelURI, final URI intermediateModelURI,
 			final GipsToIntermediate transformer) {
+		
+		ITraceManager manager = ITraceManager.getInstance();
+		if(!manager.isGIPSLTracingEnabled())
+			return;
 
 		// each project has it's own trace.
 		ITraceContext traceContext = ITraceManager.getInstance().getContext(project.getName());
@@ -333,7 +337,7 @@ public final class GipsBuilderUtils {
 				throw new IllegalArgumentException(
 						"GIPSL and Intermediate model id should not be equal: '" + gipslModelId + "'");
 
-			TraceMap<String, String> gipsl2intermediateMppings = TraceMap.normalize(transformer.getTrace(),
+			TraceMap<String, String> gipsl2intermediateMppings = TraceMap.normalize(transformer.getTracer().getMap(),
 					ResolveEcore2Id.INSTANCE, ResolveEcore2Id.INSTANCE);
 
 			traceContext

--- a/org.emoflon.gips.build/src/org/emoflon/gips/build/GipsBuilderUtils.java
+++ b/org.emoflon.gips.build/src/org/emoflon/gips/build/GipsBuilderUtils.java
@@ -338,7 +338,7 @@ public final class GipsBuilderUtils {
 				throw new IllegalArgumentException(
 						"GIPSL and Intermediate model id should not be equal: '" + gipslModelId + "'");
 
-			TraceMap<String, String> gipsl2intermediateMppings = TraceMap.normalize(transformer.getTracer().getMap(),
+			TraceMap<String, String> gipsl2intermediateMppings = TraceMap.normalize(gipsTracer.getMap(),
 					ResolveEcore2Id.INSTANCE, ResolveEcore2Id.INSTANCE);
 
 			traceContext

--- a/org.emoflon.gips.build/src/org/emoflon/gips/build/GipsBuilderUtils.java
+++ b/org.emoflon.gips.build/src/org/emoflon/gips/build/GipsBuilderUtils.java
@@ -321,14 +321,13 @@ public final class GipsBuilderUtils {
 
 		try {
 			// adjust file extension from xmi to gipsl
-			URI gipslURI = HelperEclipse.toPlatformURI(gipslModelURI.trimFileExtension().appendFileExtension("gipsl"));
+
 			// first segment of an URI is the project name, by removing it we get a
 			// project relative path
+			URI gipslURI = HelperEclipse.toPlatformURI(gipslModelURI.trimFileExtension().appendFileExtension("gipsl"));
 			IPath gipslPath = IPath.fromOSString(gipslURI.toPlatformString(true)).makeRelative().removeFirstSegments(1);
 
 			URI intermediateURI = HelperEclipse.toPlatformURI(intermediateModelURI);
-			// FIXME: the intermediate URI isn't a valid URI. The first segment is not the
-			// project name.
 			IPath intermediatePath = IPath.fromOSString(intermediateURI.toPlatformString(true)).makeRelative();
 
 			String gipslModelId = gipslPath.toString(); // gipslModelURI.trimFileExtension().lastSegment();

--- a/org.emoflon.gips.build/src/org/emoflon/gips/build/GipsBuilderUtils.java
+++ b/org.emoflon.gips.build/src/org/emoflon/gips/build/GipsBuilderUtils.java
@@ -31,6 +31,7 @@ import org.eclipse.emf.ecore.xmi.XMLResource;
 import org.eclipse.emf.ecore.xmi.impl.XMIResourceFactoryImpl;
 import org.emoflon.gips.build.generator.GipsImportManager;
 import org.emoflon.gips.build.transformation.GipsToIntermediate;
+import org.emoflon.gips.build.transformation.GipsTracer;
 import org.emoflon.gips.eclipse.api.ITraceContext;
 import org.emoflon.gips.eclipse.api.ITraceManager;
 import org.emoflon.gips.eclipse.trace.TraceMap;
@@ -310,9 +311,9 @@ public final class GipsBuilderUtils {
 	 */
 	public static void updateTrace(final IProject project, final URI gipslModelURI, final URI intermediateModelURI,
 			final GipsToIntermediate transformer) {
-		
-		ITraceManager manager = ITraceManager.getInstance();
-		if(!manager.isGIPSLTracingEnabled())
+
+		GipsTracer gipsTracer = transformer.getTracer();
+		if (!gipsTracer.isTracingEnabled())
 			return;
 
 		// each project has it's own trace.

--- a/org.emoflon.gips.build/src/org/emoflon/gips/build/transformation/GipsToIntermediate.java
+++ b/org.emoflon.gips.build/src/org/emoflon/gips/build/transformation/GipsToIntermediate.java
@@ -17,7 +17,6 @@ import org.emoflon.gips.build.transformation.helper.GipsTransformationUtils;
 import org.emoflon.gips.build.transformation.transformer.ArithmeticExpressionTransformer;
 import org.emoflon.gips.build.transformation.transformer.BooleanExpressionTransformer;
 import org.emoflon.gips.build.transformation.transformer.TransformerFactory;
-import org.emoflon.gips.eclipse.trace.TraceMap;
 import org.emoflon.gips.gipsl.gipsl.EditorGTFile;
 import org.emoflon.gips.gipsl.gipsl.GipsArithmeticExpression;
 import org.emoflon.gips.gipsl.gipsl.GipsBooleanExpression;
@@ -77,7 +76,7 @@ public class GipsToIntermediate {
 	protected GipsIntermediateFactory factory = GipsIntermediateFactory.eINSTANCE;
 	final protected GipsTransformationData data;
 	final protected TransformerFactory transformationFactory;
-	final private TraceMap<EObject, EObject> gipsl2gipsTrace = new TraceMap<>();
+	final private GipsTracer gipsl2gipsTrace = new GipsTracer();
 	protected int constraintCounter = 0;
 
 	public GipsToIntermediate(final EditorGTFile gipslFile) {
@@ -133,7 +132,7 @@ public class GipsToIntermediate {
 		return data.model();
 	}
 
-	public TraceMap<EObject, EObject> getTrace() {
+	public GipsTracer getTracer() {
 		return gipsl2gipsTrace;
 	}
 
@@ -563,7 +562,7 @@ public class GipsToIntermediate {
 			// of products.
 			linearFunction.setExpression(
 					new GipsArithmeticTransformer(factory).normalizeAndExpand(linearFunction.getExpression()));
-					gipsl2gipsTrace.map(eLinearFunction.getExpression(), linearFunction.getExpression());
+			gipsl2gipsTrace.map(eLinearFunction.getExpression(), linearFunction.getExpression());
 		}
 	}
 

--- a/org.emoflon.gips.build/src/org/emoflon/gips/build/transformation/GipsTracer.java
+++ b/org.emoflon.gips.build/src/org/emoflon/gips/build/transformation/GipsTracer.java
@@ -1,0 +1,30 @@
+package org.emoflon.gips.build.transformation;
+
+import java.util.Collection;
+
+import org.eclipse.emf.ecore.EObject;
+import org.emoflon.gips.eclipse.api.ITraceManager;
+import org.emoflon.gips.eclipse.trace.TraceMap;
+
+public class GipsTracer {
+
+	final private TraceMap<EObject, EObject> trace = new TraceMap<>();
+	final private boolean isTracingEnabled = ITraceManager.getInstance().isGIPSLTracingEnabled();
+
+	public TraceMap<EObject, EObject> getMap() {
+		return trace;
+	}
+
+	public void map(EObject source, EObject target) {
+		if (isTracingEnabled) {
+			trace.map(source, target);
+		}
+	}
+
+	public void mapOneToMany(EObject source, Collection<? extends EObject> targets) {
+		if (isTracingEnabled) {
+			trace.mapOneToMany(source, targets);
+		}
+	}
+
+}

--- a/org.emoflon.gips.build/src/org/emoflon/gips/build/transformation/GipsTracer.java
+++ b/org.emoflon.gips.build/src/org/emoflon/gips/build/transformation/GipsTracer.java
@@ -27,4 +27,8 @@ public class GipsTracer {
 		}
 	}
 
+	public boolean isTracingEnabled() {
+		return isTracingEnabled;
+	}
+
 }

--- a/org.emoflon.gips.eclipse/src/org/emoflon/gips/eclipse/api/ITraceManager.java
+++ b/org.emoflon.gips.eclipse/src/org/emoflon/gips/eclipse/api/ITraceManager.java
@@ -87,6 +87,8 @@ public interface ITraceManager {
 	boolean doesContextExist(String contextId);
 
 	boolean isVisualisationActive();
+	
+	boolean isGIPSLTracingEnabled();
 
 	/**
 	 * 

--- a/org.emoflon.gips.eclipse/src/org/emoflon/gips/eclipse/pref/PluginPreferenceInitializer.java
+++ b/org.emoflon.gips.eclipse/src/org/emoflon/gips/eclipse/pref/PluginPreferenceInitializer.java
@@ -13,17 +13,20 @@ public final class PluginPreferenceInitializer extends AbstractPreferenceInitial
 	public void initializeDefaultPreferences() {
 		var node = DefaultScope.INSTANCE.getNode(PluginPreferences.STORE_KEY);
 
-		// trace visualization is deactivated
+		// gipsl->intermediate tracing is enabled
+		node.putBoolean(PluginPreferences.PREF_GIPSL_TRACING_ENABLED, true);
+
+		// trace visualization is disabled
 		node.putBoolean(PluginPreferences.PREF_TRACE_DISPLAY_ACTIVE, false);
 
-		// code mining is deactivated
+		// code mining is disabled
 		node.putBoolean(PluginPreferences.PREF_CODE_MINING_ENABLED, false);
 
-		// RMI Service
+		// RMI Service is running
 		node.putBoolean(PluginPreferences.PREF_TRACE_RMI, true);
 		node.putInt(PluginPreferences.PREF_TRACE_RMI_PORT, IRemoteEclipseService.DEFAULT_PORT);
 
-		// trace storage
+		// trace caching is enabled
 		node.putBoolean(PluginPreferences.PREF_TRACE_CACHE_ENABLED, true);
 		node.put(PluginPreferences.PREF_TRACE_CACHE_LOCATION,
 				IPath.fromPath(Path.of("trace")).makeRelative().toPortableString());

--- a/org.emoflon.gips.eclipse/src/org/emoflon/gips/eclipse/pref/PluginPreferencePage.java
+++ b/org.emoflon.gips.eclipse/src/org/emoflon/gips/eclipse/pref/PluginPreferencePage.java
@@ -33,6 +33,9 @@ public class PluginPreferencePage extends FieldEditorPreferencePage implements I
 
 	@Override
 	protected void createFieldEditors() {
+		addField(new BooleanFieldEditor(PluginPreferences.PREF_GIPSL_TRACING_ENABLED, "&GIPSL Tracing",
+				getFieldEditorParent()));
+
 		addField(new BooleanFieldEditor(PluginPreferences.PREF_TRACE_DISPLAY_ACTIVE, "Trace &visualisation",
 				getFieldEditorParent()));
 
@@ -43,7 +46,7 @@ public class PluginPreferencePage extends FieldEditorPreferencePage implements I
 			configGroup.setText("CPLEX LP Editor");
 
 			var editorCodeMiningValues = new BooleanFieldEditor(PluginPreferences.PREF_CODE_MINING_ENABLED,
-					"Show solution &values via code mining", configGroup);
+					"Sho&w solution values via code mining", configGroup);
 			addField(editorCodeMiningValues);
 		}
 
@@ -56,7 +59,7 @@ public class PluginPreferencePage extends FieldEditorPreferencePage implements I
 			var editorRMI = new BooleanFieldEditor(PluginPreferences.PREF_TRACE_RMI, "&RMI enabled", configGroup);
 			addField(editorRMI);
 
-			var editorRMIPort = new IntegerFieldEditor(PluginPreferences.PREF_TRACE_RMI_PORT, "RMI &port", configGroup);
+			var editorRMIPort = new IntegerFieldEditor(PluginPreferences.PREF_TRACE_RMI_PORT, "RMI p&ort", configGroup);
 			editorRMIPort.setValidRange(1023, 65535);
 			addField(editorRMIPort);
 		}
@@ -77,7 +80,7 @@ public class PluginPreferencePage extends FieldEditorPreferencePage implements I
 			addField(editorTraceStore);
 
 			var editorTraceStorePath = new StringFieldEditor(PluginPreferences.PREF_TRACE_CACHE_LOCATION,
-					"Project &relative path:", configGroup);
+					"&Project relative path:", configGroup);
 			editorTraceStorePath.setEmptyStringAllowed(false);
 			editorTraceStorePath.setPropertyChangeListener(null);
 			addField(editorTraceStorePath);

--- a/org.emoflon.gips.eclipse/src/org/emoflon/gips/eclipse/pref/PluginPreferences.java
+++ b/org.emoflon.gips.eclipse/src/org/emoflon/gips/eclipse/pref/PluginPreferences.java
@@ -15,6 +15,15 @@ public final class PluginPreferences {
 	public static final String PREF_TRACE_RMI_PORT = "PREF_TRACE_RMI_PORT";
 
 	/**
+	 * Enabled/Disables tracing in GIPSL
+	 * <ul>
+	 * <li><bold>Type:</bold> {@link java.lang.Boolean}
+	 * <li>Can not be null
+	 * </ul>
+	 */
+	public static final String PREF_GIPSL_TRACING_ENABLED = "PREF_GIPSL_TRACING_ENABLED";
+
+	/**
 	 * Enables/Disables code mining for cplex editor
 	 * <ul>
 	 * <li><bold>Type:</bold> {@link java.lang.Boolean}

--- a/org.emoflon.gips.eclipse/src/org/emoflon/gips/eclipse/service/ContextManager.java
+++ b/org.emoflon.gips.eclipse/src/org/emoflon/gips/eclipse/service/ContextManager.java
@@ -129,6 +129,10 @@ public class ContextManager implements ITraceManager {
 	public boolean isVisualisationActive() {
 		return visualisationActive;
 	}
+	
+	public boolean isGIPSLTracingEnabled() {
+		return PluginPreferences.getPreferenceStore().getBoolean(PluginPreferences.PREF_GIPSL_TRACING_ENABLED);
+	}
 
 	@Override
 	public void removeListener(ITraceSelectionListener listener) {


### PR DESCRIPTION
This PR makes it possible to disable tracing for the GIPSL->Intermediate transformation. For this, a new checkbox has been added to the gipsl tracing preference page. By default, tracing is enabled.