### PR TITLE
Fixes a copy paste error within the `flipOperator(...)` method

### DIFF
--- a/org.emoflon.gips.build/src/org/emoflon/gips/build/transformation/helper/GipsTransformationUtils.java
+++ b/org.emoflon.gips.build/src/org/emoflon/gips/build/transformation/helper/GipsTransformationUtils.java
@@ -77,7 +77,7 @@ public final class GipsTransformationUtils {
 			expr.setOperator(RelationalOperator.GREATER);
 		}
 		case LESS_OR_EQUAL -> {
-			expr.setOperator(RelationalOperator.LESS_OR_EQUAL);
+			expr.setOperator(RelationalOperator.GREATER_OR_EQUAL);
 		}
 		case NOT_EQUAL -> {
 		}


### PR DESCRIPTION
Closes #267.