### PR TITLE
Adds tracing method calls to timed build problem method in GIPS engine

### DIFF
--- a/org.emoflon.gips.core/src/org/emoflon/gips/core/GipsEngine.java
+++ b/org.emoflon.gips.core/src/org/emoflon/gips/core/GipsEngine.java
@@ -63,6 +63,9 @@ public abstract class GipsEngine {
 
 				// Constraints are re-build a few lines below
 				constraints.values().stream().forEach(constraint -> constraint.clear());
+				
+				// Reset trace
+				getTracer().resetTrace();
 
 				nonMappingVariables.clear();
 				mappers.values().stream().flatMap(mapper -> mapper.getMappings().values().stream())
@@ -89,6 +92,8 @@ public abstract class GipsEngine {
 				solver.init();
 				solver.buildILPProblem();
 			});
+			
+			buildTraceGraphAndSendToIDE();
 		});
 	}
 


### PR DESCRIPTION
If I am correct, the two method calls related to tracing were missing within `GipsEngine.buildProblemTimed()`.

Can you please confirm/review this, @MarkBeB?

Thank you :-).