### PR TITLE
Add 'Delete all selections' to GIPS Trace View

### DIFF
--- a/org.emoflon.gips.eclipse/src/org/emoflon/gips/eclipse/view/menu/DeleteNode.java
+++ b/org.emoflon.gips.eclipse/src/org/emoflon/gips/eclipse/view/menu/DeleteNode.java
@@ -74,7 +74,7 @@ public class DeleteNode extends ContributionItem {
 			break;
 
 		case LinkModelNode node:
-			ProjectContext context = TracePlugin.getInstance().getContextManager().getContext(node.getContextId());
+			ProjectContext context = manager.getContext(node.getContextId());
 
 			switch (node.getDirection()) {
 			case FORWARD:

--- a/org.emoflon.gips.eclipse/src/org/emoflon/gips/eclipse/view/menu/DeleteNode.java
+++ b/org.emoflon.gips.eclipse/src/org/emoflon/gips/eclipse/view/menu/DeleteNode.java
@@ -32,59 +32,67 @@ public class DeleteNode extends ContributionItem {
 		if (!(selectionService.getSelection() instanceof IStructuredSelection structuredSelection))
 			return;
 
-		Object selectedElement = structuredSelection.getFirstElement();
+		if (structuredSelection.isEmpty())
+			return;
 
-		if (selectedElement instanceof ContextNode node) {
-			MenuItem item = new MenuItem(menu, SWT.CHECK, index);
-			item.setText("Delete context");
-			item.addSelectionListener(new SelectionAdapter() {
-				@Override
-				public void widgetSelected(SelectionEvent e) {
-					ContextManager manager = TracePlugin.getInstance().getContextManager();
-					manager.getContext(node.getContextId()).deleteAllModels();
-				}
-			});
-		} else if (selectedElement instanceof ModelNode node) {
-			MenuItem item = new MenuItem(menu, SWT.CHECK, index);
-			item.setText("Delete model");
-			item.addSelectionListener(new SelectionAdapter() {
-				@Override
-				public void widgetSelected(SelectionEvent e) {
-					ContextManager manager = TracePlugin.getInstance().getContextManager();
-					manager.getContext(node.getContextId()).deleteModel(node.getModelId());
-				}
-			});
-		} else if (selectedElement instanceof LinkModelNode node) {
-			MenuItem item = new MenuItem(menu, SWT.CHECK, index);
-			item.setText("Delete trace");
-			item.addSelectionListener(new SelectionAdapter() {
-				@Override
-				public void widgetSelected(SelectionEvent e) {
-					ProjectContext context = TracePlugin.getInstance().getContextManager()
-							.getContext(node.getContextId());
-
-					switch (node.getDirection()) {
-					case FORWARD:
-						context.deleteModelLink(node.getParent().getModelId(), node.getModelId());
-						break;
-					case BACKWARD:
-						context.deleteModelLink(node.getModelId(), node.getParent().getModelId());
-						break;
-					}
-				}
-			});
-		} else if (selectedElement instanceof ValueNode node) {
-			MenuItem item = new MenuItem(menu, SWT.CHECK, index);
-			item.setText("Delete values");
-			item.addSelectionListener(new SelectionAdapter() {
-				@Override
-				public void widgetSelected(SelectionEvent e) {
-					ProjectContext context = TracePlugin.getInstance().getContextManager()
-							.getContext(node.getContextId());
-					context.deleteModelValues(node.getModelId());
-				}
-			});
+		String buttonLabel = null;
+		if (structuredSelection.size() > 1) {
+			buttonLabel = "Delete all selections";
+		} else {
+			buttonLabel = switch (structuredSelection.getFirstElement()) {
+			case ContextNode node -> "Delete context";
+			case ModelNode node -> "Delete model";
+			case LinkModelNode node -> "Delete trace";
+			case ValueNode node -> "Delete values";
+			default -> null;
+			};
 		}
 
+		if (buttonLabel == null)
+			return;
+
+		MenuItem menuItem = new MenuItem(menu, SWT.CHECK, index);
+		menuItem.setText(buttonLabel);
+		menuItem.addSelectionListener(new SelectionAdapter() {
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				ContextManager manager = TracePlugin.getInstance().getContextManager();
+				for (Object node : structuredSelection)
+					deleteNode(manager, node);
+			}
+		});
+	}
+
+	private static void deleteNode(ContextManager manager, Object object) {
+		switch (object) {
+		case ContextNode node:
+			manager.getContext(node.getContextId()).deleteAllModels();
+			break;
+
+		case ModelNode node:
+			manager.getContext(node.getContextId()).deleteModel(node.getModelId());
+			break;
+
+		case LinkModelNode node:
+			ProjectContext context = TracePlugin.getInstance().getContextManager().getContext(node.getContextId());
+
+			switch (node.getDirection()) {
+			case FORWARD:
+				context.deleteModelLink(node.getParent().getModelId(), node.getModelId());
+				break;
+			case BACKWARD:
+				context.deleteModelLink(node.getModelId(), node.getParent().getModelId());
+				break;
+			}
+			break;
+
+		case ValueNode node:
+			manager.getContext(node.getContextId()).deleteModelValues(node.getModelId());
+			break;
+
+		case null:
+		default:
+			break;
+		}
 	}
 }


### PR DESCRIPTION
This PR adds a new menu item to the GIPS Trace View that allows all selected items to be deleted from the list. Previously, items had to be deleted individually.