### PR TITLE
Fix GIPSL code completion for context and element expressions

### DIFF
--- a/org.emoflon.gips.gipsl/src/org/emoflon/gips/gipsl/scoping/GipslScopeContextUtil.java
+++ b/org.emoflon.gips.gipsl/src/org/emoflon/gips/gipsl/scoping/GipslScopeContextUtil.java
@@ -170,6 +170,16 @@ public final class GipslScopeContextUtil {
 						|| reference == GipslPackage.Literals.GIPS_JOIN_PAIR_SELECTION__RIGHT_NODE);
 	}
 
+	public static boolean isGipsLocalContextExpressionWithAttribute(final EObject context, final EReference reference) {
+		return context instanceof GipsLocalContextExpression
+				&& reference == GipslPackage.Literals.GIPS_ATTRIBUTE_LITERAL__LITERAL;
+	}
+
+	public static boolean isGipsSetElementExpressionWithAttribute(final EObject context, final EReference reference) {
+		return context instanceof GipsSetElementExpression
+				&& reference == GipslPackage.Literals.GIPS_ATTRIBUTE_LITERAL__LITERAL;
+	}
+
 	public static Object getContainer(EObject node, Set<Class<?>> classes) {
 		if (node == null)
 			return null;

--- a/org.emoflon.gips.gipsl/src/org/emoflon/gips/gipsl/scoping/GipslScopeProvider.java
+++ b/org.emoflon.gips.gipsl/src/org/emoflon/gips/gipsl/scoping/GipslScopeProvider.java
@@ -141,6 +141,10 @@ public class GipslScopeProvider extends AbstractGipslScopeProvider {
 			return scopeForGipsTypeSelect((GipsTypeSelect) context, reference);
 		} else if (GipslScopeContextUtil.isGipsTypeQuery(context, reference)) {
 			return scopeForGipsTypeQuery((GipsTypeQuery) context, reference);
+		} else if (GipslScopeContextUtil.isGipsLocalContextExpressionWithAttribute(context, reference)) {
+			return scopeForGipsLocalContextExpressionWithAttribute((GipsLocalContextExpression) context, reference);
+		} else if (GipslScopeContextUtil.isGipsSetElementExpressionWithAttribute(context, reference)) {
+			return scopeForGipsSetElementExpressionWithAttribute((GipsSetElementExpression) context, reference);
 		} else {
 			return super.getScope(context, reference);
 		}
@@ -727,6 +731,26 @@ public class GipslScopeProvider extends AbstractGipslScopeProvider {
 
 	public IScope scopeForGipsTypeQuery(GipsTypeQuery context, EReference reference) {
 		return Scopes.scopeFor(GipslScopeContextUtil.getClasses(context));
+	}
+
+	private IScope scopeForGipsLocalContextExpressionWithAttribute(GipsLocalContextExpression context,
+			EReference reference) {
+
+		EObject localContext = GipslScopeContextUtil.getLocalContext(context);
+		if (localContext instanceof EClass eClass)
+			return Scopes.scopeFor(eClass.getEAllStructuralFeatures());
+
+		return IScope.NULLSCOPE;
+	}
+
+	private IScope scopeForGipsSetElementExpressionWithAttribute(GipsSetElementExpression context,
+			EReference reference) {
+
+		EObject setContext = GipslScopeContextUtil.getSetContext(context);
+		if (setContext instanceof GipsTypeExpression typeExpression)
+			return Scopes.scopeFor(typeExpression.getType().getEAllStructuralFeatures());
+
+		return IScope.NULLSCOPE;
 	}
 
 }


### PR DESCRIPTION
This PR (re)adds EStructualFeatures of types to the code completion. This should work for **context** and **element** expressions.
<img width="307" height="201" alt="grafik" src="https://github.com/user-attachments/assets/0989689f-be32-4d59-a5be-e3c1589a4a72" />
