### PR TITLE
Only update existing MILP Variables

### DIFF
--- a/org.emoflon.gips.core/src/org/emoflon/gips/core/milp/CplexSolver.java
+++ b/org.emoflon.gips.core/src/org/emoflon/gips/core/milp/CplexSolver.java
@@ -352,11 +352,14 @@ public class CplexSolver extends Solver {
 		for (GipsTypeExtender<?, ?> extender : engine.getTypeExtensions().values()) {
 			for (GipsTypeExtension<?> extension : extender.getExtensions()) {
 				for (Entry<String, Variable<?>> variable : extension.getVariables().entrySet()) {
-					try {
-						double result = cplex.getValue(vars.get(variable.getValue().getName()));
-						extension.setVariableValue(variable.getKey(), result);
-					} catch (final IloException ex) {
-						throw new RuntimeException(ex);
+					IloNumVar var = vars.get(variable.getValue().getName());
+					if (var != null) {
+						try {
+							double result = cplex.getValue(var);
+							extension.setVariableValue(variable.getKey(), result);
+						} catch (final IloException ex) {
+							throw new RuntimeException(ex);
+						}
 					}
 				}
 			}

--- a/org.emoflon.gips.core/src/org/emoflon/gips/core/milp/GlpkSolver.java
+++ b/org.emoflon.gips.core/src/org/emoflon/gips/core/milp/GlpkSolver.java
@@ -255,8 +255,11 @@ public class GlpkSolver extends Solver {
 		for (GipsTypeExtender<?, ?> extender : engine.getTypeExtensions().values()) {
 			for (GipsTypeExtension<?> extension : extender.getExtensions()) {
 				for (Entry<String, Variable<?>> variable : extension.getVariables().entrySet()) {
-					double result = GLPK.glp_mip_col_val(model, milpVars.get(variable.getValue().getName()).index);
-					extension.setVariableValue(variable.getKey(), result);
+					varInformation info = milpVars.get(variable.getValue().getName());
+					if (info != null) {
+						double result = GLPK.glp_mip_col_val(model, info.index);
+						extension.setVariableValue(variable.getKey(), result);
+					}
 				}
 			}
 		}

--- a/org.emoflon.gips.core/src/org/emoflon/gips/core/milp/GurobiSolver.java
+++ b/org.emoflon.gips.core/src/org/emoflon/gips/core/milp/GurobiSolver.java
@@ -414,8 +414,11 @@ public class GurobiSolver extends Solver {
 			for (GipsTypeExtension<?> extension : extender.getExtensions()) {
 				for (Entry<String, Variable<?>> variable : extension.getVariables().entrySet()) {
 					try {
-						double result = getVar(variable.getValue().getName()).get(DoubleAttr.X);
-						extension.setVariableValue(variable.getKey(), result);
+						GRBVar grbVar = getVar(variable.getValue().getName());
+						if (grbVar != null) {
+							double result = grbVar.get(DoubleAttr.X);
+							extension.setVariableValue(variable.getKey(), result);
+						}
 					} catch (final GRBException e) {
 						throw new RuntimeException(e);
 					}


### PR DESCRIPTION
TypeExtensions allow new attributes to be defined on types, which can then be used in constraints.
If these attributes are used by one or more constraints, they are translated into MILP variables.
However, if a constraint is not instantiated (e.g. because the context set is empty), no MILP variables are created. This leads to a NPE if we try to update the attributes with their MILP value.
To fix this, we check before updating whether a MILP variable exists and only update if it does.

This should fix the first point (Non-creation of type variables) of #350 