### PR TITLE
Fix for GipsConstraintValidationLog toString()

### DIFF
--- a/org.emoflon.gips.core/src/org/emoflon/gips/core/validation/GipsConstraintValidationLog.java
+++ b/org.emoflon.gips.core/src/org/emoflon/gips/core/validation/GipsConstraintValidationLog.java
@@ -39,7 +39,7 @@ public class GipsConstraintValidationLog {
 			sb.append(event);
 			sb.append("\n");
 		}
-		return super.toString();
+		return sb.toString();
 	}
 
 }


### PR DESCRIPTION
The method mistakenly delegates to its superclass's toString method instead of returning the contents of the StringBuilder that it first constructed.