### PR TITLE
Preference Page for Build plugin

### DIFF
--- a/org.emoflon.gips.build/plugin.xml
+++ b/org.emoflon.gips.build/plugin.xml
@@ -13,7 +13,7 @@
             category="org.emoflon.gips.gipsl.Gipsl"
             class="org.emoflon.gips.build.preference.PluginPreferencePage"
             id="org.emoflon.gips.build.page1"
-            name="Code Generation">
+            name="Code Generator">
       </page>
    </extension>
    <extension

--- a/org.emoflon.gips.build/plugin.xml
+++ b/org.emoflon.gips.build/plugin.xml
@@ -7,5 +7,20 @@
             class="org.emoflon.gips.build.GipsProjectBuilder">
       </builder_extension>
    </extension>
+   <extension
+         point="org.eclipse.ui.preferencePages">
+      <page
+            category="org.emoflon.gips.gipsl.Gipsl"
+            class="org.emoflon.gips.build.preference.PluginPreferencePage"
+            id="org.emoflon.gips.build.page1"
+            name="Code Generation">
+      </page>
+   </extension>
+   <extension
+         point="org.eclipse.core.runtime.preferences">
+      <initializer
+            class="org.emoflon.gips.build.preference.PluginPreferenceInitializer">
+      </initializer>
+   </extension>
 
 </plugin>

--- a/org.emoflon.gips.build/src/org/emoflon/gips/build/generator/templates/ProblemGeneratorTemplate.xtend
+++ b/org.emoflon.gips.build/src/org/emoflon/gips/build/generator/templates/ProblemGeneratorTemplate.xtend
@@ -57,6 +57,8 @@ import org.emoflon.gips.intermediate.GipsIntermediate.TypeReference
 import org.emoflon.gips.intermediate.GipsIntermediate.ValueExpression
 import org.emoflon.gips.intermediate.GipsIntermediate.Variable
 import org.emoflon.gips.intermediate.GipsIntermediate.VariableReference
+import org.emoflon.gips.build.preference.PluginPreferencePage
+import org.emoflon.gips.build.preference.PluginPreferences
 
 abstract class ProblemGeneratorTemplate<CONTEXT extends EObject> extends ClassGeneratorTemplate<CONTEXT> {
 
@@ -411,7 +413,8 @@ abstract class ProblemGeneratorTemplate<CONTEXT extends EObject> extends ClassGe
 		'''
 
 		// If a return is required, use the original implementation
-		if(requiresReturn)
+		// or if the mapping indexer is disabled
+		if(requiresReturn || PluginPreferences.isMappingIndexerDisabled)
 			return original
 
 		// Else, try to use the mapping indexer implementation
@@ -455,6 +458,7 @@ abstract class ProblemGeneratorTemplate<CONTEXT extends EObject> extends ClassGe
 		imports.add("org.emoflon.gips.core.GipsMapper")
 
 		return '''
+			// Mapping Indexer
 			final GipsMapper<?> mapper = engine.getMapper("«expression.mapping.name»");
 			final GlobalMappingIndexer globalIndexer = GlobalMappingIndexer.getInstance();
 			globalIndexer.createIndexer(mapper);

--- a/org.emoflon.gips.build/src/org/emoflon/gips/build/preference/PluginPreferenceInitializer.java
+++ b/org.emoflon.gips.build/src/org/emoflon/gips/build/preference/PluginPreferenceInitializer.java
@@ -1,0 +1,14 @@
+package org.emoflon.gips.build.preference;
+
+import org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer;
+import org.eclipse.core.runtime.preferences.DefaultScope;
+
+public class PluginPreferenceInitializer extends AbstractPreferenceInitializer {
+	@Override
+	public void initializeDefaultPreferences() {
+		var node = DefaultScope.INSTANCE.getNode(PluginPreferences.STORE_KEY);
+
+		// gipsl maping indexer is enabled
+		node.putBoolean(PluginPreferences.PREF_GIPSL_MAPPING_INDEXER, true);
+	}
+}

--- a/org.emoflon.gips.build/src/org/emoflon/gips/build/preference/PluginPreferencePage.java
+++ b/org.emoflon.gips.build/src/org/emoflon/gips/build/preference/PluginPreferencePage.java
@@ -1,0 +1,28 @@
+package org.emoflon.gips.build.preference;
+
+import org.eclipse.jface.preference.BooleanFieldEditor;
+import org.eclipse.jface.preference.FieldEditorPreferencePage;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchPreferencePage;
+
+public class PluginPreferencePage extends FieldEditorPreferencePage implements IWorkbenchPreferencePage {
+	public PluginPreferencePage() {
+		super(FieldEditorPreferencePage.GRID);
+	}
+
+	@Override
+	public void init(IWorkbench workbench) {
+		setPreferenceStore(PluginPreferences.getPreferenceStore());
+		setDescription("GIPSL Build configuration");
+	}
+
+	@Override
+	protected void createFieldEditors() {
+		var mappingIndexer = new BooleanFieldEditor(PluginPreferences.PREF_GIPSL_MAPPING_INDEXER, "Mapping &Indexer",
+				getFieldEditorParent());
+		mappingIndexer.getDescriptionControl(getFieldEditorParent()).setToolTipText(
+				"The indexer can build a look-up table for a trivial filter expression (e.g. node equals another node), which greatly accelerates the build process when such expressions are used with a large model.");
+		addField(mappingIndexer);
+
+	}
+}

--- a/org.emoflon.gips.build/src/org/emoflon/gips/build/preference/PluginPreferences.java
+++ b/org.emoflon.gips.build/src/org/emoflon/gips/build/preference/PluginPreferences.java
@@ -1,0 +1,47 @@
+package org.emoflon.gips.build.preference;
+
+import org.eclipse.core.runtime.preferences.ConfigurationScope;
+import org.eclipse.core.runtime.preferences.IScopeContext;
+import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.ui.preferences.ScopedPreferenceStore;
+
+public class PluginPreferences {
+
+	private PluginPreferences() {
+	}
+
+	private static Object lock = new Object();
+	private static ScopedPreferenceStore preferenceStore;
+
+	public static ScopedPreferenceStore getPreferenceStore() {
+		if (preferenceStore == null) {
+			synchronized (lock) {
+				if (preferenceStore == null) {
+					preferenceStore = new ScopedPreferenceStore(InstanceScope.INSTANCE, PluginPreferences.STORE_KEY);
+					preferenceStore.setSearchContexts(
+							new IScopeContext[] { InstanceScope.INSTANCE, ConfigurationScope.INSTANCE });
+				}
+			}
+		}
+		return preferenceStore;
+	}
+
+	public static final String STORE_KEY = "org.emoflon.gips.build";
+
+	/**
+	 * Enables/Disables mapping indexer
+	 * <ul>
+	 * <li><bold>Type:</bold> {@link java.lang.Boolean}
+	 * <li>Can not be null
+	 * </ul>
+	 */
+	public static final String PREF_GIPSL_MAPPING_INDEXER = "PREF_GIPSL_MAPPING_INDEXER";
+
+	public static boolean isMappingIndexerEnabled() {
+		return getPreferenceStore().getBoolean(PREF_GIPSL_MAPPING_INDEXER);
+	}
+
+	public static boolean isMappingIndexerDisabled() {
+		return !isMappingIndexerEnabled();
+	}
+}


### PR DESCRIPTION
This PR adds a new 'Code Generator' preference page under 'Gipsl'.
It contains a checkbox that can be used to enable or disable code generation for mapping indexers, which should resolve issue #359. 