### PR TITLE
Allow joinAll with different mappings but same pattern

### DIFF
--- a/org.emoflon.gips.build/src/org/emoflon/gips/build/transformation/transformer/BooleanExpressionTransformer.java
+++ b/org.emoflon.gips.build/src/org/emoflon/gips/build/transformation/transformer/BooleanExpressionTransformer.java
@@ -182,10 +182,21 @@ public class BooleanExpressionTransformer extends TransformationContext {
 		EObject localContext = GipslScopeContextUtil.getLocalContext(eJoinAll);
 		EObject setContext = GipslScopeContextUtil.getSetContext(eJoinAll);
 
-		if (setContext instanceof GipsMappingExpression && localContext instanceof GipsMapping || //
-				setContext instanceof GipsRuleExpression && localContext instanceof EditorPattern || //
+		boolean doEqualCheck = false;
+		if (setContext instanceof GipsRuleExpression && localContext instanceof EditorPattern || //
 				setContext instanceof GipsPatternExpression && localContext instanceof EditorPattern || //
 				setContext instanceof GipsTypeExpression && localContext instanceof EClass) {
+
+			doEqualCheck = true;
+
+		} else if (setContext instanceof GipsMappingExpression mappingExp
+				&& localContext instanceof GipsMapping mapping) {
+
+			doEqualCheck = mappingExp.getMapping().equals(mapping);
+
+		}
+
+		if (doEqualCheck) {
 			// -> element == context
 			ContextReference lhs = factory.createContextReference();
 			lhs.setLocal(false);
@@ -201,6 +212,8 @@ public class BooleanExpressionTransformer extends TransformationContext {
 			// element == context
 			return relation;
 		}
+
+		// Validator ensures that both sides use the same pattern or rule
 
 		EditorPattern patternRef = GipslScopeContextUtil.getPatternOrRuleOf(localContext);
 		Collection<EditorNode> nodes = GipslScopeContextUtil.getNonCreatedEditorNodes(patternRef);

--- a/org.emoflon.gips.gipsl/src/org/emoflon/gips/gipsl/validation/GipslJoinValidator.java
+++ b/org.emoflon.gips.gipsl/src/org/emoflon/gips/gipsl/validation/GipslJoinValidator.java
@@ -152,7 +152,7 @@ public class GipslJoinValidator {
 				&& localContext instanceof GipsMapping mapping) {
 			if (mappingExpression.getMapping().equals(mapping)) {
 				return; // okay!
-			} // Otherwise, check if local and set the pattern match!! (below)
+			} // Otherwise, check if local and set pattern match!! (below)
 
 		} else if (setContext instanceof GipsRuleExpression ruleExpression
 				&& localContext instanceof EditorPattern pattern) {

--- a/org.emoflon.gips.gipsl/src/org/emoflon/gips/gipsl/validation/GipslJoinValidator.java
+++ b/org.emoflon.gips.gipsl/src/org/emoflon/gips/gipsl/validation/GipslJoinValidator.java
@@ -152,14 +152,8 @@ public class GipslJoinValidator {
 				&& localContext instanceof GipsMapping mapping) {
 			if (mappingExpression.getMapping().equals(mapping)) {
 				return; // okay!
-			} else {
-				GipslValidator.warn( //
-						String.format(GipslValidatorUtil.SET_JOIN_ALL_INVALID_TYPES), //
-						operation, //
-						null //
-				);
-				return;
-			}
+			} // Otherwise, check if local and set the pattern match!! (below)
+
 		} else if (setContext instanceof GipsRuleExpression ruleExpression
 				&& localContext instanceof EditorPattern pattern) {
 			if (ruleExpression.getRule().equals(pattern)) {


### PR DESCRIPTION
This PR enables the joinAll operator to be used with different mappings (context and element), provided they share the same pattern or rule.

This will resolve #368 