### PR TITLE
Hotfix: equivalence shortcut D: swap pattern nodes A and B

### DIFF
--- a/org.emoflon.gips.gipsl/src/org/emoflon/gips/gipsl/special/pattern/EquivalenceShortcutD.java
+++ b/org.emoflon.gips.gipsl/src/org/emoflon/gips/gipsl/special/pattern/EquivalenceShortcutD.java
@@ -50,14 +50,14 @@ public class EquivalenceShortcutD extends AbstractPatternMatcher {
 			return;
 
 		if (!hasMatch()) {
-			nodeA = matchNode(leftRelational, "1");
-			nodeB = matchNode(rightRelational, "0");
+			nodeA = matchNode(leftRelational, "0");
+			nodeB = matchNode(rightRelational, "1");
 			clearPartialMatch();
 		}
 
 		if (!hasMatch()) {
-			nodeA = matchNode(rightRelational, "1");
-			nodeB = matchNode(leftRelational, "0");
+			nodeA = matchNode(rightRelational, "0");
+			nodeB = matchNode(leftRelational, "1");
 			clearPartialMatch();
 		}
 	}


### PR DESCRIPTION
@MarkBeB: I think I found the problem that caused infeasibility for the "larger" IHTC 2024 instances.

If I am not mistaken, the pattern nodes `A` and `B` have to be swapped in the equivalence shortcut D.

Can you please verify that this fix is correct? Thanks in advance.