### PR TITLE
Add a NPE check to OpenGeneratedJavaFileHandler

### DIFF
--- a/org.emoflon.gips.eclipse/src/org/emoflon/gips/eclipse/api/ITraceContext.java
+++ b/org.emoflon.gips.eclipse/src/org/emoflon/gips/eclipse/api/ITraceContext.java
@@ -40,6 +40,10 @@ public interface ITraceContext {
 
 	boolean hasModelValuesFor(String modelId);
 
+	/**
+	 * 
+	 * @return current selection or null
+	 */
 	ITraceSelection getSelectedElements();
 
 	/**

--- a/org.emoflon.gips.eclipse/src/org/emoflon/gips/eclipse/connector/EditorTraceConnection.java
+++ b/org.emoflon.gips.eclipse/src/org/emoflon/gips/eclipse/connector/EditorTraceConnection.java
@@ -153,8 +153,6 @@ public abstract class EditorTraceConnection<T extends IEditorPart> implements IE
 	 */
 	private void onEditorSelection(ISelection selection) {
 		ITraceManager service = TracePlugin.getInstance().getContextManager();
-		if (!service.isVisualisationActive())
-			return;
 
 		if (!service.doesContextExist(getContextId()))
 			return;

--- a/org.emoflon.gips.eclipse/src/org/emoflon/gips/eclipse/handler/OpenGeneratedJavaFileHandler.java
+++ b/org.emoflon.gips.eclipse/src/org/emoflon/gips/eclipse/handler/OpenGeneratedJavaFileHandler.java
@@ -64,6 +64,9 @@ public class OpenGeneratedJavaFileHandler extends AbstractHandler {
 
 		ITraceContext context = ITraceManager.getInstance().getContext(project.getName());
 		ITraceSelection traceSelection = context.getSelectedElements();
+		if (traceSelection == null)
+			return Status.error("Selection could not be found. Please (re)select the elements and repeat the action.");
+
 		IModelLink link = context.getModelChain(traceSelection.getModelId(), JAVA_MODEL_ID);
 
 		Collection<IStatus> aggregatedStatuses = new LinkedList<>();


### PR DESCRIPTION
The PR adds a NPE check to the 'Open generated Java files' command to validate that a GIPSL element has been selected. In some cases, the selection was null, resulting in an NPE. The command now informs the user to select something and re-run the command.

@maxkratz I wasn't able to reproduce the error. Could you please check that the solution is OK?